### PR TITLE
MT-703 Replace custom env: prefix by conventional $

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -342,9 +342,9 @@ Fields:
 - `endpoint` (string)
   - Default for `tracker.kind == "linear"`: `https://api.linear.app/graphql`
 - `api_key` (string)
-  - May be a literal token or `env:VAR_NAME`.
+  - May be a literal token or `$VAR_NAME`.
   - Canonical environment variable for `tracker.kind == "linear"`: `LINEAR_API_KEY`.
-  - If `env:VAR_NAME` resolves to an empty string, treat the key as missing.
+  - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
 - `project_slug` (string)
   - Required for dispatch when `tracker.kind == "linear"`.
 - `active_states` (list of strings or comma-separated string)
@@ -364,7 +364,7 @@ Fields:
 
 Fields:
 
-- `root` (path string or `env:VAR`)
+- `root` (path string or `$VAR`)
   - Default: `<system-temp>/symphony_workspaces`
   - `~` and strings containing path separators are expanded.
   - Bare strings without path separators are preserved as-is (relative roots are allowed but
@@ -473,14 +473,14 @@ Configuration precedence:
 
 1. Workflow file path selection (runtime setting -> cwd default).
 2. YAML front matter values.
-3. Environment indirection via `env:VAR_NAME` inside selected YAML values.
+3. Environment indirection via `$VAR_NAME` inside selected YAML values.
 4. Built-in defaults.
 
 Value coercion semantics:
 
 - Path/command fields support:
   - `~` home expansion
-  - `env:VAR` expansion
+  - `$VAR` expansion for env-backed path values
   - Apply expansion only to values intended to be local filesystem paths; do not rewrite URIs or
     arbitrary shell command strings.
 
@@ -525,7 +525,7 @@ Validation checks:
 
 - Workflow file can be loaded and parsed.
 - `tracker.kind` is present and supported.
-- `tracker.api_key` is present after `env:` resolution.
+- `tracker.api_key` is present after `$` resolution.
 - `tracker.project_slug` is present when required by the selected tracker kind.
 - `codex.command` is present and non-empty.
 
@@ -535,7 +535,7 @@ This section is intentionally redundant so a coding agent can implement the conf
 
 - `tracker.kind`: string, required, currently `linear`
 - `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
-- `tracker.api_key`: string or `env:VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
+- `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
 - `tracker.project_slug`: string, required when `tracker.kind=linear`
 - `tracker.active_states`: list/string, default `Todo, In Progress`
 - `tracker.terminal_states`: list/string, default `Closed, Cancelled, Canceled, Duplicate, Done`
@@ -1568,7 +1568,7 @@ Recommended additional hardening for ports:
 
 ### 15.3 Secret Handling
 
-- Support `env:VAR` indirection in workflow config.
+- Support `$VAR` indirection in workflow config.
 - Do not log API tokens or secret env values.
 - Validate presence of secrets without printing them.
 
@@ -1818,8 +1818,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Front matter non-map returns typed error
 - Config defaults apply when optional values are missing
 - `tracker.kind` validation enforces currently supported kind (`linear`)
-- `tracker.api_key` works (including `env:VAR` indirection)
-- `env:VAR` resolution works for tracker API key and path values
+- `tracker.api_key` works (including `$VAR` indirection)
+- `$VAR` resolution works for tracker API key and path values
 - `~` path expansion works
 - `codex.command` is preserved as a shell command string
 - Per-state concurrency override map normalizes state names and ignores invalid values
@@ -1946,7 +1946,7 @@ Use the same validation profiles as Section 17:
 
 - Workflow path selection supports explicit runtime path and cwd default
 - `WORKFLOW.md` loader with YAML front matter + prompt body split
-- Typed config layer with defaults and `env:` resolution
+- Typed config layer with defaults and `$` resolution
 - Dynamic `WORKFLOW.md` watch/reload/re-apply for config and prompt
 - Polling orchestrator with single-authority mutable state
 - Issue tracker client with candidate fetch + state refresh + terminal fetch

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -84,20 +84,21 @@ Notes:
   identifier, title, and body.
 - Use `hooks.after_create` to bootstrap a fresh workspace. For a Git-backed repo, you can run
   `git clone ... .` there, along with any other setup commands you need.
-- `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `env:LINEAR_API_KEY`.
-- For path values, `~` is expanded to the home directory and values prefixed with `env:VAR` are
-  replaced by `$VAR` before use. Example:
+- `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
+- For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling,
+  while `codex.command` stays a shell command string and any `$VAR` expansion there happens in the
+  launched shell. Example:
 
   ```yaml
   workspace:
-    root: "env:SYMPHONY_WORKSPACE_ROOT"
+    root: "$SYMPHONY_WORKSPACE_ROOT"
   hooks:
     after_create: |
       git clone --depth 1 "$SOURCE_REPO_URL" .
   tracker:
-    api_key: "env:LINEAR_API_KEY"
+    api_key: "$LINEAR_API_KEY"
   codex:
-    command: "env:CODEX_BIN app-server --model gpt-5.3-codex"
+    command: "$CODEX_BIN app-server --model gpt-5.3-codex"
   ```
 
 - If `WORKFLOW.md` is missing or has invalid YAML, startup and scheduling are halted until fixed.

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -519,18 +519,18 @@ defmodule SymphonyElixir.Config do
   defp resolve_env_value(value, fallback) when is_binary(value) do
     trimmed = String.trim(value)
 
-    if String.starts_with?(trimmed, "env:") do
-      trimmed
-      |> String.trim_leading("env:")
-      |> String.trim()
-      |> System.get_env()
-      |> then(fn
-        nil -> fallback
-        "" -> nil
-        env_value -> env_value
-      end)
-    else
-      trimmed
+    case env_reference_name(trimmed) do
+      {:ok, env_name} ->
+        env_name
+        |> System.get_env()
+        |> then(fn
+          nil -> fallback
+          "" -> nil
+          env_value -> env_value
+        end)
+
+      :error ->
+        trimmed
     end
   end
 
@@ -539,15 +539,21 @@ defmodule SymphonyElixir.Config do
   defp normalize_path_token(value) when is_binary(value) do
     trimmed = String.trim(value)
 
-    if String.starts_with?(trimmed, "env:") do
-      trimmed
-      |> String.trim_leading("env:")
-      |> String.trim()
-      |> resolve_env_token()
-    else
-      trimmed
+    case env_reference_name(trimmed) do
+      {:ok, env_name} -> resolve_env_token(env_name)
+      :error -> trimmed
     end
   end
+
+  defp env_reference_name("$" <> env_name) do
+    if String.match?(env_name, ~r/^[A-Za-z_][A-Za-z0-9_]*$/) do
+      {:ok, env_name}
+    else
+      :error
+    end
+  end
+
+  defp env_reference_name(_value), do: :error
 
   defp resolve_env_token(value) do
     case System.get_env(value) do

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -584,23 +584,59 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Config.codex_command() == "codex app-server"
   end
 
-  test "config resolves path values with ~ and env var references" do
-    env_var = "SYMP_WORKSPACE_ROOT_#{System.unique_integer([:positive])}"
+  test "config resolves $VAR references for env-backed secret and path values" do
+    workspace_env_var = "SYMP_WORKSPACE_ROOT_#{System.unique_integer([:positive])}"
+    api_key_env_var = "SYMP_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
     workspace_root = Path.join("/tmp", "symphony-workspace-root")
+    api_key = "resolved-secret"
     codex_bin = Path.join(["~", "bin", "codex"])
 
-    previous_workspace_root = System.get_env(env_var)
+    previous_workspace_root = System.get_env(workspace_env_var)
+    previous_api_key = System.get_env(api_key_env_var)
 
-    System.put_env(env_var, workspace_root)
-    on_exit(fn -> restore_env(env_var, previous_workspace_root) end)
+    System.put_env(workspace_env_var, workspace_root)
+    System.put_env(api_key_env_var, api_key)
+
+    on_exit(fn ->
+      restore_env(workspace_env_var, previous_workspace_root)
+      restore_env(api_key_env_var, previous_api_key)
+    end)
 
     write_workflow_file!(Workflow.workflow_file_path(),
-      workspace_root: "env:#{env_var}",
+      tracker_api_token: "$#{api_key_env_var}",
+      workspace_root: "$#{workspace_env_var}",
       codex_command: "#{codex_bin} app-server"
     )
 
+    assert Config.linear_api_token() == api_key
     assert Config.workspace_root() == Path.expand(workspace_root)
     assert Config.codex_command() == "#{codex_bin} app-server"
+  end
+
+  test "config no longer resolves legacy env: references" do
+    workspace_env_var = "SYMP_WORKSPACE_ROOT_#{System.unique_integer([:positive])}"
+    api_key_env_var = "SYMP_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
+    workspace_root = Path.join("/tmp", "symphony-workspace-root")
+    api_key = "resolved-secret"
+
+    previous_workspace_root = System.get_env(workspace_env_var)
+    previous_api_key = System.get_env(api_key_env_var)
+
+    System.put_env(workspace_env_var, workspace_root)
+    System.put_env(api_key_env_var, api_key)
+
+    on_exit(fn ->
+      restore_env(workspace_env_var, previous_workspace_root)
+      restore_env(api_key_env_var, previous_api_key)
+    end)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "env:#{api_key_env_var}",
+      workspace_root: "env:#{workspace_env_var}"
+    )
+
+    assert Config.linear_api_token() == "env:#{api_key_env_var}"
+    assert Config.workspace_root() == "env:#{workspace_env_var}"
   end
 
   test "config supports per-state max concurrent agent overrides" do


### PR DESCRIPTION
#### Context

Unify env-variable interpolation so `WORKFLOW.md` uses `$VAR` only.

#### TL;DR

Replace `env:` config indirection with `$` and update docs/specs accordingly.

#### Summary

- Remove legacy `env:` resolution in config path and secret resolution paths.
- Add regression coverage for `$` env references and literal `env:` behavior.
- Update README and SPEC to document `$` as the only config indirection syntax.

#### Alternatives

- Keeping `env:` compatibility was intentionally rejected to complete a clean cutover with no migration path.

#### Test Plan

- [x] `mix test test/symphony_elixir/core_test.exs test/symphony_elixir/workspace_and_config_test.exs`
- [x] `mix specs.check`
- [ ] `make -C elixir all`
