### PR TITLE
Turn before_remove into a Mix task

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -66,6 +66,9 @@ workspace:
 hooks:
   after_create: |
     git clone git@github.com:your-org/your-repo.git .
+    if command -v mise >/dev/null 2>&1; then
+      cd elixir && mise trust && mise exec -- mix deps.get
+    fi
 agent:
   max_concurrent_agents: 10
 codex:
@@ -84,6 +87,8 @@ Notes:
   identifier, title, and body.
 - Use `hooks.after_create` to bootstrap a fresh workspace. For a Git-backed repo, you can run
   `git clone ... .` there, along with any other setup commands you need.
+- If a hook needs `mise exec` inside a freshly cloned workspace, trust the repo config and fetch
+  the project deps in `hooks.after_create` before invoking `mise` later from other hooks.
 - `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `env:LINEAR_API_KEY`.
 - For path values, `~` is expanded to the home directory and values prefixed with `env:VAR` are
   replaced by `$VAR` before use. Example:
@@ -94,6 +99,9 @@ Notes:
   hooks:
     after_create: |
       git clone --depth 1 "$SOURCE_REPO_URL" .
+      if command -v mise >/dev/null 2>&1; then
+        cd elixir && mise trust && mise exec -- mix deps.get
+      fi
   tracker:
     api_key: "env:LINEAR_API_KEY"
   codex:
@@ -125,9 +133,11 @@ mise exec -- elixir --version
 ```bash
 git clone https://github.com/openai/symphony
 cd symphony/elixir
-mix setup
-mix build
-./bin/symphony ./WORKFLOW.md
+mise trust
+mise install
+mise exec -- mix setup
+mise exec -- mix build
+mise exec -- ./bin/symphony ./WORKFLOW.md
 ```
 
 ## Testing

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -22,28 +22,11 @@ workspace:
 hooks:
   after_create: |
     git clone --depth 1 https://github.com/openai/symphony .
+    if command -v mise >/dev/null 2>&1; then
+      cd elixir && mise trust && mise exec -- mix deps.get
+    fi
   before_remove: |
-    branch="$(git branch --show-current 2>/dev/null || true)"
-    if [ -z "$branch" ]; then
-      exit 0
-    fi
-    if ! command -v gh >/dev/null 2>&1; then
-      exit 0
-    fi
-    if ! gh auth status >/dev/null 2>&1; then
-      exit 0
-    fi
-    gh pr list \
-      --repo openai/symphony \
-      --head "$branch" \
-      --state open \
-      --json number \
-      --jq '.[].number' | while read -r pr_number; do
-      [ -n "$pr_number" ] || continue
-      gh pr close "$pr_number" \
-        --repo openai/symphony \
-        --comment "Closing because the Linear issue for branch $branch entered a terminal state without merge." || true
-    done
+    cd elixir && mise exec -- mix workspace.before_remove
 agent:
   max_concurrent_agents: 10
 codex:

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -1,0 +1,140 @@
+defmodule Mix.Tasks.Workspace.BeforeRemove do
+  use Mix.Task
+
+  @shortdoc "Close open GitHub PRs for the current branch before workspace removal"
+
+  @moduledoc """
+  Closes open pull requests for the current Git branch.
+
+  This task is intended for use from the `before_remove` workspace hook.
+
+  Usage:
+
+      mix workspace.before_remove
+      mix workspace.before_remove --branch feature/my-branch
+      mix workspace.before_remove --repo openai/symphony
+  """
+
+  @default_repo "openai/symphony"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _argv, invalid} =
+      OptionParser.parse(args,
+        strict: [branch: :string, help: :boolean, repo: :string],
+        aliases: [h: :help]
+      )
+
+    cond do
+      opts[:help] ->
+        Mix.shell().info(@moduledoc)
+
+      invalid != [] ->
+        Mix.raise("Invalid option(s): #{inspect(invalid)}")
+
+      true ->
+        repo = opts[:repo] || @default_repo
+        branch = opts[:branch] || current_branch()
+
+        maybe_close_open_pull_requests(repo, branch)
+    end
+  end
+
+  defp maybe_close_open_pull_requests(_repo, nil), do: :ok
+
+  defp maybe_close_open_pull_requests(repo, branch) do
+    if gh_available?() and gh_authenticated?() do
+      repo
+      |> list_open_pull_request_numbers(branch)
+      |> Enum.each(&close_pull_request(repo, branch, &1))
+    end
+
+    :ok
+  end
+
+  defp gh_available? do
+    not is_nil(System.find_executable("gh"))
+  end
+
+  defp gh_authenticated? do
+    match?({:ok, _output}, run_command("gh", ["auth", "status"]))
+  end
+
+  defp list_open_pull_request_numbers(repo, branch) do
+    case run_command("gh", [
+           "pr",
+           "list",
+           "--repo",
+           repo,
+           "--head",
+           branch,
+           "--state",
+           "open",
+           "--json",
+           "number",
+           "--jq",
+           ".[].number"
+         ]) do
+      {:ok, output} ->
+        output
+        |> String.split("\n", trim: true)
+        |> Enum.reject(&(&1 == ""))
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp close_pull_request(repo, branch, pr_number) do
+    case run_command("gh", [
+           "pr",
+           "close",
+           pr_number,
+           "--repo",
+           repo,
+           "--comment",
+           closing_comment(branch)
+         ]) do
+      {:ok, _output} ->
+        Mix.shell().info("Closed PR ##{pr_number} for branch #{branch}")
+
+      {:error, {status, output}} ->
+        trimmed_output = String.trim(output)
+
+        Mix.shell().error("Failed to close PR ##{pr_number} for branch #{branch}: exit #{status}#{format_output(trimmed_output)}")
+    end
+  end
+
+  defp closing_comment(branch) do
+    "Closing because the Linear issue for branch #{branch} entered a terminal state without merge."
+  end
+
+  defp format_output(""), do: ""
+  defp format_output(output), do: " output=#{inspect(output)}"
+
+  defp current_branch do
+    case run_command("git", ["branch", "--show-current"]) do
+      {:ok, output} ->
+        case String.trim(output) do
+          "" -> nil
+          branch -> branch
+        end
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  defp run_command(command, args) do
+    case System.find_executable(command) do
+      nil ->
+        {:error, {:enoent, ""}}
+
+      path ->
+        case System.cmd(path, args, stderr_to_stdout: true) do
+          {output, 0} -> {:ok, output}
+          {output, status} -> {:error, {status, output}}
+        end
+    end
+  end
+end

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -1,0 +1,358 @@
+defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
+  use ExUnit.Case, async: false
+
+  alias Mix.Tasks.Workspace.BeforeRemove
+
+  import ExUnit.CaptureIO
+
+  setup do
+    Mix.Task.reenable("workspace.before_remove")
+    :ok
+  end
+
+  test "prints help" do
+    output =
+      capture_io(fn ->
+        BeforeRemove.run(["--help"])
+      end)
+
+    assert output =~ "mix workspace.before_remove"
+  end
+
+  test "fails on invalid options" do
+    assert_raise Mix.Error, ~r/Invalid option/, fn ->
+      BeforeRemove.run(["--wat"])
+    end
+  end
+
+  test "no-ops when branch is unavailable" do
+    with_path([], fn ->
+      in_temp_dir(fn ->
+        output =
+          capture_io(fn ->
+            BeforeRemove.run([])
+          end)
+
+        assert output == ""
+      end)
+    end)
+  end
+
+  test "no-ops when gh is unavailable" do
+    with_path([], fn ->
+      output =
+        capture_io(fn ->
+          BeforeRemove.run(["--branch", "feature/no-gh"])
+        end)
+
+      assert output == ""
+    end)
+  end
+
+  test "uses current branch for lookup when branch option is omitted" do
+    with_fake_gh_and_git(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+        printf '101\n102\n'
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "101" ]; then
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "102" ]; then
+        printf 'boom\n' >&2
+        exit 17
+      fi
+
+      exit 99
+      """,
+      """
+      #!/bin/sh
+      printf 'feature/workpad\n'
+      exit 0
+      """,
+      fn log_path ->
+        output =
+          capture_io(fn ->
+            BeforeRemove.run([])
+          end)
+
+        assert output =~ "Closed PR #101 for branch feature/workpad"
+
+        log = File.read!(log_path)
+
+        assert log =~
+                 "pr list --repo openai/symphony --head feature/workpad --state open --json number --jq .[].number"
+
+        assert log =~ "pr close 101 --repo openai/symphony"
+        assert log =~ "pr close 102 --repo openai/symphony"
+      end
+    )
+  end
+
+  test "closes open pull requests for the branch and tolerates close failures" do
+    with_fake_gh(fn log_path ->
+      File.write!(log_path, "")
+
+      BeforeRemove.run(["--branch", "feature/workpad"])
+
+      log = File.read!(log_path)
+
+      assert log =~ "auth status"
+      assert log =~ "pr list --repo openai/symphony --head feature/workpad --state open --json number --jq .[].number"
+      assert log =~ "pr close 101 --repo openai/symphony"
+      assert log =~ "pr close 102 --repo openai/symphony"
+
+      error_output =
+        capture_io(:stderr, fn ->
+          Mix.Task.reenable("workspace.before_remove")
+          BeforeRemove.run(["--branch", "feature/workpad"])
+        end)
+
+      assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
+    end)
+  end
+
+  test "formats close failures without command stderr output" do
+    with_fake_gh(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+        printf '102\n'
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "102" ]; then
+        exit 17
+      fi
+
+      exit 99
+      """,
+      fn log_path ->
+        error_output =
+          capture_io(:stderr, fn ->
+            Mix.Task.reenable("workspace.before_remove")
+            BeforeRemove.run(["--branch", "feature/no-output"])
+          end)
+
+        assert error_output =~ "Failed to close PR #102 for branch feature/no-output: exit 17"
+        refute error_output =~ "output="
+        log = File.read!(log_path)
+        assert log =~ "pr list --repo openai/symphony --head feature/no-output --state open --json number --jq .[].number"
+        assert log =~ "pr close 102 --repo openai/symphony"
+      end
+    )
+  end
+
+  test "no-ops when PR list fails for current branch" do
+    with_fake_gh(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 0
+      fi
+
+      if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+        exit 1
+      fi
+
+      exit 99
+      """,
+      fn log_path ->
+        output =
+          capture_io(fn ->
+            BeforeRemove.run(["--branch", "feature/list-fails"])
+          end)
+
+        assert output == ""
+
+        log = File.read!(log_path)
+        assert log =~ "auth status"
+
+        assert log =~
+                 "pr list --repo openai/symphony --head feature/list-fails --state open --json number --jq .[].number"
+
+        refute log =~ "pr close"
+      end
+    )
+  end
+
+  test "no-ops when git current branch is blank" do
+    with_fake_gh_and_git(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 0
+      fi
+
+      exit 99
+      """,
+      """
+      #!/bin/sh
+      printf '\n'
+      exit 0
+      """,
+      fn log_path ->
+        output =
+          capture_io(fn ->
+            BeforeRemove.run([])
+          end)
+
+        assert output == ""
+
+        log = File.read!(log_path)
+        assert log == ""
+        refute log =~ "pr list"
+      end
+    )
+  end
+
+  test "no-ops when gh auth is unavailable" do
+    with_fake_gh(
+      """
+      #!/bin/sh
+      printf '%s\n' "$*" >> "$GH_LOG"
+      if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+        exit 1
+      fi
+      exit 99
+      """,
+      fn log_path ->
+        BeforeRemove.run(["--branch", "feature/no-auth"])
+
+        log = File.read!(log_path)
+        assert log =~ "auth status"
+        refute log =~ "pr list"
+      end
+    )
+  end
+
+  defp with_fake_gh(fun) do
+    with_fake_binaries(
+      %{
+        "gh" => """
+        #!/bin/sh
+        printf '%s\n' "$*" >> "$GH_LOG"
+
+        if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+          exit 0
+        fi
+
+        if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+          printf '101\n102\n'
+          exit 0
+        fi
+
+        if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "101" ]; then
+          exit 0
+        fi
+
+        if [ "$1" = "pr" ] && [ "$2" = "close" ] && [ "$3" = "102" ]; then
+          printf 'boom\n' >&2
+          exit 17
+        fi
+
+        exit 99
+        """
+      },
+      fun
+    )
+  end
+
+  defp with_fake_gh(script, fun) do
+    with_fake_binaries(%{"gh" => script}, fun)
+  end
+
+  defp with_fake_gh_and_git(gh_script, git_script, fun) do
+    with_fake_binaries(%{"gh" => gh_script, "git" => git_script}, fun)
+  end
+
+  defp with_fake_binaries(scripts, fun) do
+    unique = System.unique_integer([:positive, :monotonic])
+    root = Path.join(System.tmp_dir!(), "workspace-before-remove-task-test-#{unique}")
+    bin_dir = Path.join(root, "bin")
+    log_path = Path.join(root, "gh.log")
+
+    try do
+      File.rm_rf!(root)
+      File.mkdir_p!(bin_dir)
+      File.write!(log_path, "")
+      original_path = System.get_env("PATH") || ""
+      path_with_binaries = Enum.join([bin_dir, original_path], ":")
+
+      Enum.each(scripts, fn {name, script} ->
+        path = Path.join(bin_dir, name)
+        File.write!(path, script)
+        File.chmod!(path, 0o755)
+      end)
+
+      with_env(
+        %{
+          "GH_LOG" => log_path,
+          "PATH" => path_with_binaries
+        },
+        fn ->
+          fun.(log_path)
+        end
+      )
+    after
+      File.rm_rf!(root)
+    end
+  end
+
+  defp with_path(paths, fun) do
+    with_env(%{"PATH" => Enum.join(paths, ":")}, fun)
+  end
+
+  defp with_env(overrides, fun) do
+    keys = Map.keys(overrides)
+    previous = Map.new(keys, fn key -> {key, System.get_env(key)} end)
+
+    try do
+      Enum.each(overrides, fn {key, value} -> System.put_env(key, value) end)
+      fun.()
+    after
+      Enum.each(previous, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+    end
+  end
+
+  defp in_temp_dir(fun) do
+    unique = System.unique_integer([:positive, :monotonic])
+    root = Path.join(System.tmp_dir!(), "workspace-before-remove-empty-dir-#{unique}")
+
+    File.rm_rf!(root)
+    File.mkdir_p!(root)
+
+    original_cwd = File.cwd!()
+
+    try do
+      File.cd!(root)
+      fun.()
+    after
+      File.cd!(original_cwd)
+      File.rm_rf!(root)
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -57,6 +57,13 @@ defmodule SymphonyElixir.CoreTest do
     assert is_list(Map.get(tracker, "active_states"))
     assert is_list(Map.get(tracker, "terminal_states"))
 
+    hooks = Map.get(config, "hooks", %{})
+    assert is_map(hooks)
+    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/openai/symphony ."
+    assert Map.get(hooks, "after_create") =~ "cd elixir && mise trust"
+    assert Map.get(hooks, "after_create") =~ "mise exec -- mix deps.get"
+    assert Map.get(hooks, "before_remove") =~ "cd elixir && mise exec -- mix workspace.before_remove"
+
     assert String.trim(prompt) != ""
     assert is_binary(Config.workflow_prompt())
     assert Config.workflow_prompt() == prompt


### PR DESCRIPTION
#### Context

Simplify workspace `before_remove` by replacing inline shell with a first-class Mix task and ensure fresh clones trust mise before running Elixir commands.

#### TL;DR

Turn `before_remove` into a Mix task and update hooks to use it through mise.

#### Summary

- Add `mix workspace.before_remove` task to close open PRs for the active branch.
- Replace inline shell hook in `elixir/WORKFLOW.md` with `mise exec -- mix workspace.before_remove`.
- Add `mise trust` to `after_create` before `mix deps.get`.
- Add tests for the new Mix task and workflow hook expectations.

#### Alternatives

- Keep inline shell in `WORKFLOW.md` (rejected for maintainability and readability).

#### Test Plan

- [x] `cd elixir && mise trust && mix test test/mix/tasks/workspace_before_remove_test.exs test/symphony_elixir/core_test.exs`
- [x] `cd elixir && mise trust && mise exec -- make all`
- [ ] Fresh clone trust/no-trust and before_remove workflow proof
