### PR TITLE
Add startup immediate poll unit test

### DIFF
--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -453,6 +453,49 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert %{polling: %{checking?: true, next_poll_in_ms: nil}} = snapshot
   end
 
+  test "orchestrator triggers an immediate poll cycle shortly after startup" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil, poll_interval_ms: 5_000)
+
+    orchestrator_name = Module.concat(__MODULE__, :ImmediateStartupOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    assert %{polling: %{checking?: true}} =
+             wait_for_snapshot(
+               pid,
+               fn
+                 %{polling: %{checking?: true}} ->
+                   true
+
+                 _ ->
+                   false
+               end,
+               500
+             )
+
+    assert %{polling: %{checking?: false, next_poll_in_ms: next_poll_in_ms, poll_interval_ms: 5_000}} =
+             wait_for_snapshot(
+               pid,
+               fn
+                 %{polling: %{checking?: false, next_poll_in_ms: due_in_ms}}
+                 when is_integer(due_in_ms) and due_in_ms <= 5_000 ->
+                   true
+
+                 _ ->
+                   false
+               end,
+               500
+             )
+
+    assert is_integer(next_poll_in_ms)
+    assert next_poll_in_ms >= 0
+  end
+
   test "orchestrator poll cycle resets next refresh countdown after a check" do
     write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil, poll_interval_ms: 50)
 


### PR DESCRIPTION
#### Context

Startup refresh should run immediately after app boot so users don't wait an extra polling interval on initial load.

#### TL;DR

Add a unit test proving Orchestrator starts a poll cycle immediately on startup.

#### Summary

- Add a startup poll unit test that waits for checking state right after startup.
- Assert the polling state transitions back to not checking with refreshed countdown.

#### Alternatives

- No code changes were needed since startup already schedules `schedule_tick(0)` on init.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mix test test/symphony_elixir/orchestrator_status_test.exs:413 test/symphony_elixir/orchestrator_status_test.exs:456 test/symphony_elixir/orchestrator_status_test.exs:499`
