### PR TITLE
Require explicit acknowledgement for high-trust startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Symphony turns project work into isolated, autonomous implementation runs, allow
 work instead of supervising coding agents.
 
 > [!WARNING]
-> Symphony is a low-key engineering preview.
+> Symphony is a low-key engineering preview for testing in trusted environments.
 
 ## Running Symphony
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,9 +19,10 @@ The service solves four operational problems:
   settings with their code.
 - It provides enough observability to operate and debug multiple concurrent agent runs.
 
-The service is designed for trusted environments. It intentionally runs the coding agent in a
-non-interactive, auto-approved mode and relies on workspace/path safety controls to prevent the most
-dangerous mistakes.
+Implementations are expected to document their trust and safety posture explicitly. This
+specification does not require a single approval, sandbox, or operator-confirmation policy; some
+implementations may target trusted environments with a high-trust configuration, while others may
+require stricter approvals or sandboxing.
 
 Important boundary:
 
@@ -51,8 +52,9 @@ Important boundary:
 - General-purpose workflow engine or distributed job scheduler.
 - Built-in business logic for how to edit tickets, PRs, or comments. (That logic lives in the
   workflow prompt and agent tooling.)
-- Strong sandbox controls beyond what the coding agent and host OS provide. The default runtime is
-  explicitly high-trust.
+- Mandating strong sandbox controls beyond what the coding agent and host OS provide.
+- Mandating a single default approval, sandbox, or operator-confirmation posture for all
+  implementations.
 
 ## 3. System Overview
 
@@ -900,8 +902,8 @@ semantics):
 ```json
 {"id":1,"method":"initialize","params":{"clientInfo":{"name":"symphony","version":"1.0"},"capabilities":{}}}
 {"method":"initialized","params":{}}
-{"id":2,"method":"thread/start","params":{"approvalPolicy":"never","sandbox":"danger-full-access","cwd":"/abs/workspace"}}
-{"id":3,"method":"turn/start","params":{"threadId":"<thread-id>","input":[{"type":"text","text":"<rendered prompt>"}],"cwd":"/abs/workspace","title":"ABC-123: Example","approvalPolicy":"never","sandboxPolicy":{"type":"dangerFullAccess"}}}
+{"id":2,"method":"thread/start","params":{"approvalPolicy":"<implementation-defined>","sandbox":"<implementation-defined>","cwd":"/abs/workspace"}}
+{"id":3,"method":"turn/start","params":{"threadId":"<thread-id>","input":[{"type":"text","text":"<rendered prompt>"}],"cwd":"/abs/workspace","title":"ABC-123: Example","approvalPolicy":"<implementation-defined>","sandboxPolicy":{"type":"<implementation-defined>"}}}
 ```
 
 1. `initialize` request
@@ -914,8 +916,8 @@ semantics):
 2. `initialized` notification
 3. `thread/start` request
    - Params include:
-     - `approvalPolicy` = `never`
-     - `sandbox` = `danger-full-access`
+     - `approvalPolicy` = implementation-defined session approval policy value
+     - `sandbox` = implementation-defined session sandbox value
      - `cwd` = absolute workspace path
      - If optional client-side tools are implemented, include their advertised tool specs using the
        protocol mechanism supported by the targeted Codex app-server version.
@@ -925,8 +927,9 @@ semantics):
      - `input` = single text item containing rendered prompt
      - `cwd`
      - `title` = `<issue.identifier>: <issue.title>`
-     - `approvalPolicy` = `never`
-     - `sandboxPolicy` = object form (for example `{type: "dangerFullAccess"}`)
+     - `approvalPolicy` = implementation-defined turn approval policy value
+     - `sandboxPolicy` = implementation-defined object-form sandbox policy payload when required by
+       the targeted app-server version
 
 Session identifiers:
 
@@ -966,7 +969,7 @@ include:
 - optional `usage` map (token counts)
 - payload fields as needed
 
-Important emitted events:
+Important emitted events may include:
 
 - `session_started`
 - `startup_failed`
@@ -983,12 +986,21 @@ Important emitted events:
 
 ### 10.5 Approval, Tool Calls, and User Input Policy
 
-Symphony runs in non-interactive mode.
+Approval, sandbox, and user-input behavior is implementation-defined.
 
-Auto-approval behavior:
+Policy requirements:
+
+- Each implementation should document its chosen approval, sandbox, and operator-confirmation
+  posture.
+- Approval requests and user-input-required events must not leave a run stalled indefinitely. An
+  implementation should either satisfy them, surface them to an operator, auto-resolve them, or
+  fail the run according to its documented policy.
+
+Example high-trust behavior:
 
 - Auto-approve command execution approvals for the session.
 - Auto-approve file-change approvals for the session.
+- Treat user-input-required turns as hard failure.
 
 Unsupported dynamic tool calls:
 
@@ -1544,13 +1556,16 @@ Operators can control behavior by:
 
 ### 15.1 Trust Boundary Assumption
 
-Symphony is designed for trusted environments.
+Each implementation defines its own trust boundary.
 
-Current safety tradeoff:
+Operational safety requirements:
 
-- The coding agent runs with non-interactive approvals and danger-full-access sandbox policy.
-- Safety is enforced primarily through workspace isolation and path validation, not strict sandbox
-  controls.
+- Implementations should state clearly whether they are intended for trusted environments, more
+  restrictive environments, or both.
+- Implementations should state clearly whether they rely on auto-approved actions, operator
+  approvals, stricter sandboxing, or some combination of those controls.
+- Workspace isolation and path validation are important baseline controls, but they are not a
+  substitute for whatever approval and sandbox policy an implementation chooses.
 
 ### 15.2 Filesystem Safety Requirements
 
@@ -1879,16 +1894,17 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Startup handshake sends `initialize`, `initialized`, `thread/start`, `turn/start`
 - `initialize` includes client identity/capabilities payload required by the targeted Codex
   app-server protocol
-- `turn/start` uses object-form sandbox policy payload
+- Policy-related startup payloads use the implementation's documented approval/sandbox settings
 - `thread/start` and `turn/start` parse nested IDs and emit `session_started`
 - Request/response read timeout is enforced
 - Turn timeout is enforced
 - Partial JSON lines are buffered until newline
 - Stdout and stderr are handled separately; protocol JSON is parsed from stdout only
 - Non-JSON stderr lines are logged but do not crash parsing
-- Command/file-change approvals are auto-approved
+- Command/file-change approvals are handled according to the implementation's documented policy
 - Unsupported dynamic tool calls are rejected without stalling the session
-- User input requests cause hard failure (`turn_input_required`)
+- User input requests are handled according to the implementation's documented policy and do not
+  stall indefinitely
 - Usage and rate-limit payloads are extracted from nested payload shapes
 - Compatible payload variants for approvals, user-input-required signals, and usage/rate-limit
   telemetry are accepted when they preserve the same logical meaning

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -4,7 +4,7 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 [`SPEC.md`](../SPEC.md) in the repository root.
 
 > [!WARNING]
-> Symphony is a low-key engineering preview.
+> SymphonyElixir is preview software for testing in trusted environments. It is presented as-is.
 
 ## Screenshot
 

--- a/elixir/lib/symphony_elixir/cli.ex
+++ b/elixir/lib/symphony_elixir/cli.ex
@@ -5,7 +5,8 @@ defmodule SymphonyElixir.CLI do
 
   alias SymphonyElixir.LogFile
 
-  @switches [logs_root: :string, port: :integer]
+  @acknowledgement_switch :i_understand_that_this_will_be_running_without_the_usual_guardrails
+  @switches [{@acknowledgement_switch, :boolean}, logs_root: :string, port: :integer]
 
   @type ensure_started_result :: {:ok, [atom()]} | {:error, term()}
   @type deps :: %{
@@ -32,13 +33,15 @@ defmodule SymphonyElixir.CLI do
   def evaluate(args, deps \\ runtime_deps()) do
     case OptionParser.parse(args, strict: @switches) do
       {opts, [], []} ->
-        with :ok <- maybe_set_logs_root(opts, deps),
+        with :ok <- require_guardrails_acknowledgement(opts),
+             :ok <- maybe_set_logs_root(opts, deps),
              :ok <- maybe_set_server_port(opts, deps) do
           run(Path.expand("WORKFLOW.md"), deps)
         end
 
       {opts, [workflow_path], []} ->
-        with :ok <- maybe_set_logs_root(opts, deps),
+        with :ok <- require_guardrails_acknowledgement(opts),
+             :ok <- maybe_set_logs_root(opts, deps),
              :ok <- maybe_set_server_port(opts, deps) do
           run(workflow_path, deps)
         end
@@ -97,6 +100,47 @@ defmodule SymphonyElixir.CLI do
           :ok = deps.set_logs_root.(Path.expand(logs_root))
         end
     end
+  end
+
+  defp require_guardrails_acknowledgement(opts) do
+    if Keyword.get(opts, @acknowledgement_switch, false) do
+      :ok
+    else
+      {:error, acknowledgement_banner()}
+    end
+  end
+
+  @spec acknowledgement_banner() :: String.t()
+  defp acknowledgement_banner do
+    lines = [
+      "This Symphony implementation is a low key engineering preview.",
+      "Codex will run without any guardrails.",
+      "SymphonyElixir is not a supported product and is presented as-is.",
+      "To proceed, start with `--i-understand-that-this-will-be-running-without-the-usual-guardrails` CLI argument"
+    ]
+
+    width = Enum.max(Enum.map(lines, &String.length/1))
+    border = String.duplicate("─", width + 2)
+    top = "╭" <> border <> "╮"
+    bottom = "╰" <> border <> "╯"
+    spacer = "│ " <> String.duplicate(" ", width) <> " │"
+
+    content =
+      [
+        top,
+        spacer
+        | Enum.map(lines, fn line ->
+            "│ " <> String.pad_trailing(line, width) <> " │"
+          end)
+      ] ++ [spacer, bottom]
+
+    [
+      IO.ANSI.red(),
+      IO.ANSI.bright(),
+      Enum.join(content, "\n"),
+      IO.ANSI.reset()
+    ]
+    |> IO.iodata_to_binary()
   end
 
   defp set_logs_root(logs_root) do

--- a/elixir/test/symphony_elixir/cli_test.exs
+++ b/elixir/test/symphony_elixir/cli_test.exs
@@ -3,6 +3,46 @@ defmodule SymphonyElixir.CLITest do
 
   alias SymphonyElixir.CLI
 
+  @ack_flag "--i-understand-that-this-will-be-running-without-the-usual-guardrails"
+
+  test "returns the guardrails acknowledgement banner when the flag is missing" do
+    parent = self()
+
+    deps = %{
+      file_regular?: fn _path ->
+        send(parent, :file_checked)
+        true
+      end,
+      set_workflow_file_path: fn _path ->
+        send(parent, :workflow_set)
+        :ok
+      end,
+      set_logs_root: fn _path ->
+        send(parent, :logs_root_set)
+        :ok
+      end,
+      set_server_port_override: fn _port ->
+        send(parent, :port_set)
+        :ok
+      end,
+      ensure_all_started: fn ->
+        send(parent, :started)
+        {:ok, [:symphony_elixir]}
+      end
+    }
+
+    assert {:error, banner} = CLI.evaluate(["WORKFLOW.md"], deps)
+    assert banner =~ "This Symphony implementation is a low key engineering preview."
+    assert banner =~ "Codex will run without any guardrails."
+    assert banner =~ "SymphonyElixir is not a supported product and is presented as-is."
+    assert banner =~ @ack_flag
+    refute_received :file_checked
+    refute_received :workflow_set
+    refute_received :logs_root_set
+    refute_received :port_set
+    refute_received :started
+  end
+
   test "defaults to WORKFLOW.md when workflow path is missing" do
     deps = %{
       file_regular?: fn path -> Path.basename(path) == "WORKFLOW.md" end,
@@ -12,7 +52,7 @@ defmodule SymphonyElixir.CLITest do
       ensure_all_started: fn -> {:ok, [:symphony_elixir]} end
     }
 
-    assert :ok = CLI.evaluate([], deps)
+    assert :ok = CLI.evaluate([@ack_flag], deps)
   end
 
   test "accepts --logs-root and passes an expanded root to runtime deps" do
@@ -29,7 +69,7 @@ defmodule SymphonyElixir.CLITest do
       ensure_all_started: fn -> {:ok, [:symphony_elixir]} end
     }
 
-    assert :ok = CLI.evaluate(["--logs-root", "tmp/custom-logs", "WORKFLOW.md"], deps)
+    assert :ok = CLI.evaluate([@ack_flag, "--logs-root", "tmp/custom-logs", "WORKFLOW.md"], deps)
     assert_received {:logs_root, expanded_path}
     assert expanded_path == Path.expand("tmp/custom-logs")
   end
@@ -43,7 +83,7 @@ defmodule SymphonyElixir.CLITest do
       ensure_all_started: fn -> {:ok, [:symphony_elixir]} end
     }
 
-    assert {:error, message} = CLI.evaluate(["WORKFLOW.md"], deps)
+    assert {:error, message} = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
     assert message =~ "Workflow file not found:"
   end
 
@@ -56,7 +96,7 @@ defmodule SymphonyElixir.CLITest do
       ensure_all_started: fn -> {:error, :boom} end
     }
 
-    assert {:error, message} = CLI.evaluate(["WORKFLOW.md"], deps)
+    assert {:error, message} = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
     assert message =~ "Failed to start Symphony with workflow"
     assert message =~ ":boom"
   end
@@ -70,6 +110,6 @@ defmodule SymphonyElixir.CLITest do
       ensure_all_started: fn -> {:ok, [:symphony_elixir]} end
     }
 
-    assert :ok = CLI.evaluate(["WORKFLOW.md"], deps)
+    assert :ok = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
   end
 end


### PR DESCRIPTION
#### Context

The reference implementation currently runs Codex in a high-trust mode, but the
spec over-prescribed that posture and startup did not require an explicit
operator acknowledgement.

#### TL;DR

*Require an explicit startup acknowledgement for the high-trust Elixir runtime and loosen the spec's policy stance.*

#### Summary

- Add a required CLI acknowledgement gate before SymphonyElixir starts Codex in its current mode
- Show a styled warning banner and add CLI coverage for the missing-flag failure path
- Update the spec and preview docs so approval and sandbox policy are left to implementors

#### Alternatives

- Keep the current startup flow and rely only on documentation warnings: rejected because it still
  starts the high-trust runtime too implicitly
- Change the Elixir runtime policies now instead of gating startup: rejected because this task was
  to preserve the existing implementation posture while making it explicitly acknowledged

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/cli_test.exs`
