### PR TITLE
Remove leftover SYMPHONY_WORKFLOW_FILE_PATH

### DIFF
--- a/elixir/lib/symphony_elixir/workflow.ex
+++ b/elixir/lib/symphony_elixir/workflow.ex
@@ -6,12 +6,10 @@ defmodule SymphonyElixir.Workflow do
   alias SymphonyElixir.WorkflowStore
 
   @workflow_file_name "WORKFLOW.md"
-  @workflow_file_env "SYMPHONY_WORKFLOW_FILE_PATH"
 
   @spec workflow_file_path() :: Path.t()
   def workflow_file_path do
     Application.get_env(:symphony_elixir, :workflow_file_path) ||
-      System.get_env(@workflow_file_env) ||
       Path.join(File.cwd!(), @workflow_file_name)
   end
 

--- a/elixir/test/symphony_elixir/cli_test.exs
+++ b/elixir/test/symphony_elixir/cli_test.exs
@@ -55,6 +55,30 @@ defmodule SymphonyElixir.CLITest do
     assert :ok = CLI.evaluate([@ack_flag], deps)
   end
 
+  test "uses an explicit workflow path override when provided" do
+    parent = self()
+    workflow_path = "tmp/custom/WORKFLOW.md"
+    expanded_path = Path.expand(workflow_path)
+
+    deps = %{
+      file_regular?: fn path ->
+        send(parent, {:workflow_checked, path})
+        path == expanded_path
+      end,
+      set_workflow_file_path: fn path ->
+        send(parent, {:workflow_set, path})
+        :ok
+      end,
+      set_logs_root: fn _path -> :ok end,
+      set_server_port_override: fn _port -> :ok end,
+      ensure_all_started: fn -> {:ok, [:symphony_elixir]} end
+    }
+
+    assert :ok = CLI.evaluate([@ack_flag, workflow_path], deps)
+    assert_received {:workflow_checked, ^expanded_path}
+    assert_received {:workflow_set, ^expanded_path}
+  end
+
   test "accepts --logs-root and passes an expanded root to runtime deps" do
     parent = self()
 

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -94,32 +94,25 @@ defmodule SymphonyElixir.CoreTest do
     assert :ok = Config.validate!()
   end
 
-  test "workflow file path resolves from SYMPHONY_WORKFLOW_FILE_PATH when app env is unset" do
+  test "workflow file path defaults to WORKFLOW.md in the current working directory when app env is unset" do
     original_workflow_path = Workflow.workflow_file_path()
-    previous_env_path = System.get_env("SYMPHONY_WORKFLOW_FILE_PATH")
-    external_workflow_path = "/tmp/external/WORKFLOW.md"
 
     on_exit(fn ->
-      restore_env("SYMPHONY_WORKFLOW_FILE_PATH", previous_env_path)
       Workflow.set_workflow_file_path(original_workflow_path)
     end)
 
     Workflow.clear_workflow_file_path()
-    System.put_env("SYMPHONY_WORKFLOW_FILE_PATH", external_workflow_path)
 
-    assert Workflow.workflow_file_path() == external_workflow_path
+    assert Workflow.workflow_file_path() == Path.join(File.cwd!(), "WORKFLOW.md")
   end
 
-  test "workflow file path prefers app env over SYMPHONY_WORKFLOW_FILE_PATH" do
-    previous_env_path = System.get_env("SYMPHONY_WORKFLOW_FILE_PATH")
+  test "workflow file path resolves from app env when set" do
     app_workflow_path = "/tmp/app/WORKFLOW.md"
 
     on_exit(fn ->
-      restore_env("SYMPHONY_WORKFLOW_FILE_PATH", previous_env_path)
       Workflow.clear_workflow_file_path()
     end)
 
-    System.put_env("SYMPHONY_WORKFLOW_FILE_PATH", "/tmp/env/WORKFLOW.md")
     Workflow.set_workflow_file_path(app_workflow_path)
 
     assert Workflow.workflow_file_path() == app_workflow_path


### PR DESCRIPTION
#### Context

`SYMPHONY_WORKFLOW_FILE_PATH` was removed from the supported workflow spec, but the Elixir runtime still used it as a fallback when no explicit workflow path was configured.

#### TL;DR

*Remove the dead workflow-path env var fallback and align tests with the supported path resolution behavior.*

#### Summary

- Remove `SYMPHONY_WORKFLOW_FILE_PATH` from `SymphonyElixir.Workflow.workflow_file_path/0`
- Cover the supported default cwd fallback and app-config override in core tests
- Add focused CLI coverage for explicit workflow path handoff

#### Alternatives

- Keep the env var fallback for backwards compatibility, but that would preserve behavior the spec no longer supports
- Remove the fallback without test updates, but that would leave the contract around default and explicit overrides under-specified

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/core_test.exs test/symphony_elixir/cli_test.exs`
