### PR TITLE
Prevent duplicate Symphony processes per Linear project

### DIFF
--- a/elixir/lib/symphony_elixir.ex
+++ b/elixir/lib/symphony_elixir.ex
@@ -24,6 +24,7 @@ defmodule SymphonyElixir.Application do
     :ok = SymphonyElixir.LogFile.configure()
 
     children = [
+      SymphonyElixir.ProjectLock,
       {Task.Supervisor, name: SymphonyElixir.TaskSupervisor},
       SymphonyElixir.WorkflowStore,
       SymphonyElixir.Orchestrator,

--- a/elixir/lib/symphony_elixir/cli.ex
+++ b/elixir/lib/symphony_elixir/cli.ex
@@ -63,7 +63,7 @@ defmodule SymphonyElixir.CLI do
           :ok
 
         {:error, reason} ->
-          {:error, "Failed to start Symphony with workflow #{expanded_path}: #{inspect(reason)}"}
+          {:error, "Failed to start Symphony with workflow #{expanded_path}: #{format_start_error(reason)}"}
       end
     else
       {:error, "Workflow file not found: #{expanded_path}"}
@@ -168,6 +168,26 @@ defmodule SymphonyElixir.CLI do
     Application.put_env(:symphony_elixir, :server_port_override, port)
     :ok
   end
+
+  defp format_start_error({:symphony_elixir, reason}), do: format_start_error(reason)
+
+  defp format_start_error({reason, {SymphonyElixir.Application, :start, _args}}),
+    do: format_start_error(reason)
+
+  defp format_start_error({:shutdown, {:failed_to_start_child, SymphonyElixir.ProjectLock, reason}}),
+    do: format_start_error(reason)
+
+  defp format_start_error({:failed_to_start_child, SymphonyElixir.ProjectLock, reason}),
+    do: format_start_error(reason)
+
+  defp format_start_error({:project_already_running, owner}),
+    do: SymphonyElixir.ProjectLock.duplicate_start_message(owner)
+
+  defp format_start_error({:project_lock_unavailable, project_slug, lock_path, reason}) do
+    "could not acquire startup lock for Linear project #{project_slug} at #{lock_path}: #{inspect(reason)}"
+  end
+
+  defp format_start_error(reason), do: inspect(reason)
 
   @spec wait_for_shutdown() :: no_return()
   defp wait_for_shutdown do

--- a/elixir/lib/symphony_elixir/project_lock.ex
+++ b/elixir/lib/symphony_elixir/project_lock.ex
@@ -1,0 +1,376 @@
+defmodule SymphonyElixir.ProjectLock do
+  @moduledoc """
+  Prevents multiple Symphony processes on the same host from serving the same
+  Linear project at the same time.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias SymphonyElixir.{Config, Workflow}
+
+  @lock_root_name "symphony-project-locks"
+  @metadata_file "owner.json"
+
+  @type owner :: %{
+          optional(:cwd) => String.t(),
+          optional(:details) => String.t(),
+          optional(:hostname) => String.t(),
+          optional(:instance_id) => String.t(),
+          optional(:lock_path) => String.t(),
+          optional(:pid) => pos_integer(),
+          optional(:project_slug) => String.t(),
+          optional(:started_at) => String.t(),
+          optional(:workflow_path) => String.t()
+        }
+
+  @type state :: %{
+          lock_path: String.t() | nil,
+          metadata_path: String.t() | nil,
+          owner: owner() | nil
+        }
+
+  @type pid_probe :: (pos_integer() -> boolean() | :unknown)
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    start_opts =
+      case Keyword.fetch(opts, :name) do
+        {:ok, name} -> [name: name]
+        :error -> []
+      end
+
+    GenServer.start_link(__MODULE__, opts, start_opts)
+  end
+
+  @doc false
+  @spec lock_path_for_test(String.t(), Path.t()) :: Path.t()
+  def lock_path_for_test(project_slug, lock_root) when is_binary(project_slug) and is_binary(lock_root) do
+    build_lock_path(Path.expand(lock_root), project_slug)
+  end
+
+  @spec duplicate_start_message(map()) :: String.t()
+  def duplicate_start_message(owner) when is_map(owner) do
+    owner = normalize_owner(owner)
+
+    message_prefix(owner) <>
+      pid_segment(owner) <>
+      workflow_segment(owner) <>
+      cwd_segment(owner) <>
+      detail_segment(owner)
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    case acquire_lock(runtime_config(opts)) do
+      {:ok, state} ->
+        {:ok, state}
+
+      {:error, {:project_already_running, owner} = reason} ->
+        Logger.error(duplicate_start_message(owner))
+        {:stop, reason}
+
+      {:error, {:project_lock_unavailable, project_slug, lock_path, lock_reason} = reason} ->
+        Logger.error(lock_unavailable_message(project_slug, lock_path, lock_reason))
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, %{lock_path: nil}), do: :ok
+
+  def terminate(_reason, %{lock_path: lock_path, metadata_path: metadata_path, owner: owner}) do
+    release_lock(lock_path, metadata_path, owner)
+    :ok
+  end
+
+  def terminate(_reason, _state), do: :ok
+
+  defp runtime_config(opts) do
+    tracker_kind = Keyword.get_lazy(opts, :tracker_kind, &Config.tracker_kind/0)
+    project_slug = Keyword.get_lazy(opts, :project_slug, &Config.linear_project_slug/0)
+    lock_root = opts |> Keyword.get(:lock_root, default_lock_root()) |> Path.expand()
+    pid_probe = Keyword.get(opts, :pid_alive?, &os_pid_alive?/1)
+
+    owner = %{
+      instance_id: Keyword.get(opts, :instance_id, random_instance_id()),
+      project_slug: project_slug,
+      hostname: Keyword.get(opts, :hostname, hostname()),
+      pid: opts |> Keyword.get(:os_pid, System.pid()) |> normalize_pid(),
+      workflow_path: Keyword.get(opts, :workflow_path, Workflow.workflow_file_path()),
+      cwd: Keyword.get_lazy(opts, :cwd, &File.cwd!/0),
+      started_at: Keyword.get(opts, :started_at, DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601())
+    }
+
+    %{lock_root: lock_root, owner: owner, pid_probe: pid_probe, tracker_kind: tracker_kind}
+  end
+
+  defp acquire_lock(%{tracker_kind: "linear", owner: %{project_slug: project_slug} = owner} = config)
+       when is_binary(project_slug) and project_slug != "" do
+    lock_path = build_lock_path(config.lock_root, project_slug)
+    metadata_path = Path.join(lock_path, @metadata_file)
+    owner = Map.put(owner, :lock_path, lock_path)
+
+    case File.mkdir_p(config.lock_root) do
+      :ok ->
+        do_acquire_lock(lock_path, metadata_path, owner, config.pid_probe)
+
+      {:error, reason} ->
+        {:error, {:project_lock_unavailable, project_slug, lock_path, reason}}
+    end
+  end
+
+  defp acquire_lock(_config), do: {:ok, %{lock_path: nil, metadata_path: nil, owner: nil}}
+
+  defp do_acquire_lock(lock_path, metadata_path, owner, pid_probe) do
+    project_slug = Map.fetch!(owner, :project_slug)
+
+    case File.mkdir(lock_path) do
+      :ok ->
+        case write_owner(metadata_path, owner) do
+          :ok ->
+            {:ok, %{lock_path: lock_path, metadata_path: metadata_path, owner: owner}}
+
+          {:error, reason} ->
+            remove_lock_dir(lock_path)
+            {:error, {:project_lock_unavailable, project_slug, lock_path, reason}}
+        end
+
+      {:error, :eexist} ->
+        recover_or_reject_existing_lock(lock_path, metadata_path, owner, pid_probe)
+
+      {:error, reason} ->
+        {:error, {:project_lock_unavailable, project_slug, lock_path, reason}}
+    end
+  end
+
+  defp recover_or_reject_existing_lock(lock_path, metadata_path, owner, pid_probe) do
+    project_slug = Map.fetch!(owner, :project_slug)
+
+    case read_owner(metadata_path) do
+      {:ok, existing_owner} ->
+        handle_existing_owner(existing_owner, lock_path, metadata_path, owner, pid_probe)
+
+      {:error, reason} ->
+        {:error, existing_lock_metadata_error(project_slug, lock_path, reason)}
+    end
+  end
+
+  defp handle_existing_owner(existing_owner, lock_path, metadata_path, owner, pid_probe) do
+    existing_owner = Map.put(existing_owner, :lock_path, lock_path)
+
+    if stale_owner?(existing_owner, pid_probe) do
+      recover_stale_lock(lock_path, metadata_path, owner, pid_probe)
+    else
+      {:error, {:project_already_running, existing_owner}}
+    end
+  end
+
+  defp recover_stale_lock(lock_path, metadata_path, owner, pid_probe) do
+    project_slug = Map.fetch!(owner, :project_slug)
+    Logger.warning("Removing stale project lock for Linear project #{project_slug} at #{lock_path}")
+
+    case remove_lock_dir(lock_path) do
+      :ok ->
+        do_acquire_lock(lock_path, metadata_path, owner, pid_probe)
+
+      {:error, reason} ->
+        {:error, {:project_lock_unavailable, project_slug, lock_path, reason}}
+    end
+  end
+
+  defp write_owner(metadata_path, owner) do
+    owner
+    |> owner_payload()
+    |> Jason.encode()
+    |> case do
+      {:ok, payload} -> File.write(metadata_path, payload)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp read_owner(metadata_path) do
+    with {:ok, payload} <- File.read(metadata_path),
+         {:ok, owner} <- Jason.decode(payload) do
+      {:ok, normalize_owner(owner)}
+    end
+  end
+
+  defp release_lock(lock_path, metadata_path, owner) when is_binary(lock_path) and is_map(owner) do
+    with {:ok, current_owner} <- read_owner(metadata_path),
+         true <- same_owner?(current_owner, owner) do
+      case remove_lock_dir(lock_path) do
+        :ok ->
+          :ok
+
+        {:error, reason} ->
+          Logger.warning("Failed to release project lock #{lock_path}: #{inspect(reason)}")
+      end
+    else
+      _ -> :ok
+    end
+  end
+
+  defp release_lock(_lock_path, _metadata_path, _owner), do: :ok
+
+  defp remove_lock_dir(lock_path) do
+    case File.rm_rf(lock_path) do
+      {:ok, _paths} -> :ok
+      {:error, reason, _path} -> {:error, reason}
+    end
+  end
+
+  defp stale_owner?(owner, pid_probe) do
+    case Map.get(owner, :pid) do
+      pid when is_integer(pid) and pid > 0 ->
+        case pid_probe.(pid) do
+          false -> true
+          _ -> false
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  defp same_owner?(owner_a, owner_b) do
+    Map.get(normalize_owner(owner_a), :instance_id) ==
+      Map.get(normalize_owner(owner_b), :instance_id)
+  end
+
+  defp owner_payload(owner) do
+    owner
+    |> normalize_owner()
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Enum.into(%{})
+  end
+
+  defp normalize_owner(owner) do
+    %{
+      instance_id: get_owner_field(owner, :instance_id),
+      project_slug: get_owner_field(owner, :project_slug),
+      hostname: get_owner_field(owner, :hostname),
+      pid: owner |> get_owner_field(:pid) |> normalize_pid(),
+      workflow_path: get_owner_field(owner, :workflow_path),
+      cwd: get_owner_field(owner, :cwd),
+      started_at: get_owner_field(owner, :started_at),
+      lock_path: get_owner_field(owner, :lock_path),
+      details: get_owner_field(owner, :details)
+    }
+  end
+
+  defp get_owner_field(owner, field) when is_map(owner) do
+    Map.get(owner, field) || Map.get(owner, Atom.to_string(field))
+  end
+
+  defp normalize_pid(pid) when is_integer(pid) and pid > 0, do: pid
+
+  defp normalize_pid(pid) when is_binary(pid) do
+    case Integer.parse(pid) do
+      {value, ""} when value > 0 -> value
+      _ -> nil
+    end
+  end
+
+  defp normalize_pid(_pid), do: nil
+
+  defp lock_unavailable_message(project_slug, lock_path, reason) do
+    "could not acquire startup lock for Linear project #{project_slug} at #{lock_path}: #{inspect(reason)}"
+  end
+
+  defp message_prefix(owner) do
+    project_slug = Map.get(owner, :project_slug, "unknown")
+    hostname = Map.get(owner, :hostname, "unknown host")
+
+    "another Symphony process is already serving Linear project #{project_slug} on #{hostname}"
+  end
+
+  defp pid_segment(%{pid: pid}) when is_integer(pid) and pid > 0, do: " (pid #{pid})"
+  defp pid_segment(_owner), do: ""
+
+  defp workflow_segment(%{workflow_path: path}) when is_binary(path) and path != "", do: " using #{path}"
+  defp workflow_segment(_owner), do: ""
+
+  defp cwd_segment(%{cwd: path}) when is_binary(path) and path != "", do: " from #{path}"
+  defp cwd_segment(_owner), do: ""
+
+  defp detail_segment(%{details: value}) when is_binary(value) and value != "", do: "; #{value}"
+  defp detail_segment(_owner), do: ""
+
+  defp existing_lock_metadata_error(project_slug, lock_path, reason) do
+    {:project_already_running,
+     %{
+       project_slug: project_slug,
+       lock_path: lock_path,
+       details: "startup lock exists but owner metadata is unavailable (#{inspect(reason)})"
+     }}
+  end
+
+  defp default_lock_root, do: Path.join(System.tmp_dir!(), @lock_root_name)
+
+  defp build_lock_path(lock_root, project_slug) do
+    suffix =
+      :crypto.hash(:sha256, project_slug)
+      |> Base.encode16(case: :lower)
+      |> binary_part(0, 12)
+
+    prefix =
+      project_slug
+      |> String.downcase()
+      |> String.replace(~r/[^a-z0-9._-]+/u, "-")
+      |> String.trim("-")
+      |> case do
+        "" -> "project"
+        value -> String.slice(value, 0, 40)
+      end
+
+    Path.join(lock_root, "#{prefix}-#{suffix}")
+  end
+
+  defp random_instance_id do
+    :crypto.strong_rand_bytes(8)
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc false
+  @spec hostname_for_test((-> {:ok, charlist() | String.t()} | term())) :: String.t()
+  def hostname_for_test(gethostname_fun \\ &:inet.gethostname/0) do
+    case gethostname_fun.() do
+      {:ok, hostname} -> to_string(hostname)
+      _ -> "unknown-host"
+    end
+  end
+
+  defp hostname, do: hostname_for_test()
+
+  @doc false
+  @spec os_pid_alive_for_test(integer() | term()) :: boolean() | :unknown
+  def os_pid_alive_for_test(pid), do: os_pid_alive_for_test(pid, &System.find_executable/1, &System.cmd/3)
+
+  @doc false
+  @spec os_pid_alive_for_test(
+          integer() | term(),
+          (String.t() -> String.t() | nil),
+          (String.t(), [String.t()], keyword() -> {String.t(), integer()})
+        ) :: boolean() | :unknown
+  def os_pid_alive_for_test(pid, find_executable_fun, system_cmd_fun)
+      when is_integer(pid) and pid > 0 do
+    case find_executable_fun.("kill") do
+      nil ->
+        :unknown
+
+      kill_binary ->
+        case system_cmd_fun.(kill_binary, ["-0", Integer.to_string(pid)], stderr_to_stdout: true) do
+          {_output, 0} -> true
+          {_output, _status} -> false
+        end
+    end
+  end
+
+  def os_pid_alive_for_test(_pid, _find_executable_fun, _system_cmd_fun), do: :unknown
+
+  defp os_pid_alive?(pid), do: os_pid_alive_for_test(pid)
+end

--- a/elixir/test/symphony_elixir/cli_test.exs
+++ b/elixir/test/symphony_elixir/cli_test.exs
@@ -112,4 +112,59 @@ defmodule SymphonyElixir.CLITest do
 
     assert :ok = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
   end
+
+  test "surfaces duplicate project startup errors clearly" do
+    deps = %{
+      file_regular?: fn _path -> true end,
+      set_workflow_file_path: fn _path -> :ok end,
+      set_logs_root: fn _path -> :ok end,
+      set_server_port_override: fn _port -> :ok end,
+      ensure_all_started: fn ->
+        {:error,
+         {:symphony_elixir,
+          {:shutdown,
+           {:failed_to_start_child, SymphonyElixir.ProjectLock,
+            {:project_already_running,
+             %{
+               project_slug: "project-alpha",
+               hostname: "host-a",
+               pid: 4242,
+               workflow_path: "/tmp/WORKFLOW.md",
+               cwd: "/tmp/workspace"
+             }}}}}}
+      end
+    }
+
+    assert {:error, message} = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
+    assert message =~ "another Symphony process is already serving Linear project project-alpha"
+    assert message =~ "host-a"
+    assert message =~ "pid 4242"
+  end
+
+  test "unwraps duplicate project startup errors from application-start tuples" do
+    deps = %{
+      file_regular?: fn _path -> true end,
+      set_workflow_file_path: fn _path -> :ok end,
+      set_logs_root: fn _path -> :ok end,
+      set_server_port_override: fn _port -> :ok end,
+      ensure_all_started: fn ->
+        {:error,
+         {{:shutdown,
+           {:failed_to_start_child, SymphonyElixir.ProjectLock,
+            {:project_already_running,
+             %{
+               project_slug: "project-beta",
+               hostname: "host-b",
+               pid: 5252,
+               workflow_path: "/tmp/WORKFLOW.md",
+               cwd: "/tmp/workspace"
+             }}}}, {SymphonyElixir.Application, :start, [:normal, []]}}}
+      end
+    }
+
+    assert {:error, message} = CLI.evaluate([@ack_flag, "WORKFLOW.md"], deps)
+    assert message =~ "another Symphony process is already serving Linear project project-beta"
+    assert message =~ "host-b"
+    assert message =~ "pid 5252"
+  end
 end

--- a/elixir/test/symphony_elixir/project_lock_test.exs
+++ b/elixir/test/symphony_elixir/project_lock_test.exs
@@ -1,0 +1,471 @@
+defmodule SymphonyElixir.ProjectLockTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias SymphonyElixir.{ProjectLock, Workflow}
+
+  setup do
+    unique =
+      6
+      |> :crypto.strong_rand_bytes()
+      |> Base.encode16(case: :lower)
+
+    lock_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-project-lock-test-#{System.system_time(:nanosecond)}-#{unique}"
+      )
+
+    File.rm_rf(lock_root)
+    File.mkdir_p!(lock_root)
+    on_exit(fn -> File.rm_rf(lock_root) end)
+
+    {:ok, lock_root: lock_root}
+  end
+
+  test "blocks a second startup for the same project until the first one exits", %{lock_root: lock_root} do
+    pid_probe = fn pid -> pid == 11_111 end
+
+    {:ok, first_pid} =
+      start_supervised(
+        temporary_child_spec(
+          Module.concat(__MODULE__, :FirstSameProject),
+          project_lock_opts(
+            name: Module.concat(__MODULE__, :FirstSameProject),
+            project_slug: "same-project",
+            lock_root: lock_root,
+            os_pid: "11111",
+            pid_alive?: pid_probe
+          )
+        )
+      )
+
+    assert {:error, {:project_already_running, owner}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :SecondSameProject),
+                   project_slug: "same-project",
+                   lock_root: lock_root,
+                   os_pid: "22222",
+                   pid_alive?: pid_probe
+                 )
+               )
+             end)
+
+    assert owner.project_slug == "same-project"
+    assert owner.pid == 11_111
+
+    GenServer.stop(first_pid)
+
+    assert {:ok, second_pid} =
+             ProjectLock.start_link(
+               project_lock_opts(
+                 name: Module.concat(__MODULE__, :ThirdSameProject),
+                 project_slug: "same-project",
+                 lock_root: lock_root,
+                 os_pid: "22222",
+                 pid_alive?: fn _pid -> false end
+               )
+             )
+
+    GenServer.stop(second_pid)
+  end
+
+  test "allows concurrent startups for different projects", %{lock_root: lock_root} do
+    {:ok, _first_pid} =
+      start_supervised(
+        {ProjectLock,
+         project_lock_opts(
+           name: Module.concat(__MODULE__, :ProjectOne),
+           project_slug: "project-one",
+           lock_root: lock_root,
+           os_pid: "10001"
+         )}
+      )
+
+    assert {:ok, second_pid} =
+             ProjectLock.start_link(
+               project_lock_opts(
+                 name: Module.concat(__MODULE__, :ProjectTwo),
+                 project_slug: "project-two",
+                 lock_root: lock_root,
+                 os_pid: "10002"
+               )
+             )
+
+    GenServer.stop(second_pid)
+  end
+
+  test "reclaims a stale lock when the recorded pid is no longer alive", %{lock_root: lock_root} do
+    lock_path = ProjectLock.lock_path_for_test("stale-project", lock_root)
+    File.mkdir_p!(lock_path)
+
+    File.write!(
+      Path.join(lock_path, "owner.json"),
+      Jason.encode!(%{
+        instance_id: "stale-owner",
+        project_slug: "stale-project",
+        hostname: "old-host",
+        pid: 99_999,
+        workflow_path: "/tmp/stale-workflow.md",
+        cwd: "/tmp/stale-workspace",
+        started_at: "2026-02-27T22:30:00Z"
+      })
+    )
+
+    assert {:ok, pid} =
+             ProjectLock.start_link(
+               project_lock_opts(
+                 name: Module.concat(__MODULE__, :RecoveredProject),
+                 project_slug: "stale-project",
+                 lock_root: lock_root,
+                 os_pid: "33333",
+                 pid_alive?: fn _pid -> false end
+               )
+             )
+
+    owner =
+      lock_path
+      |> Path.join("owner.json")
+      |> File.read!()
+      |> Jason.decode!()
+
+    assert owner["project_slug"] == "stale-project"
+    assert owner["pid"] == 33_333
+    refute owner["instance_id"] == "stale-owner"
+
+    GenServer.stop(pid)
+  end
+
+  test "skips locking when the tracker is not linear" do
+    assert {:ok, pid} =
+             ProjectLock.start_link(
+               project_lock_opts(
+                 name: Module.concat(__MODULE__, :MemoryTracker),
+                 tracker_kind: "memory",
+                 project_slug: nil
+               )
+             )
+
+    assert %{lock_path: nil, metadata_path: nil, owner: nil} = :sys.get_state(pid)
+    GenServer.stop(pid)
+  end
+
+  test "surfaces metadata-unavailable details when the lock owner file is unreadable", %{lock_root: lock_root} do
+    lock_path = ProjectLock.lock_path_for_test("broken-project", lock_root)
+    File.mkdir_p!(lock_path)
+    File.write!(Path.join(lock_path, "owner.json"), "")
+
+    assert {:error, {:project_already_running, owner}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :BrokenProject),
+                   project_slug: "broken-project",
+                   lock_root: lock_root
+                 )
+               )
+             end)
+
+    assert owner.project_slug == "broken-project"
+    assert owner.lock_path == lock_path
+    assert owner.details =~ "owner metadata is unavailable"
+  end
+
+  test "reports lock-root creation failures explicitly", %{lock_root: lock_root} do
+    blocked_parent = Path.join(lock_root, "not-a-directory")
+    bad_root = Path.join(blocked_parent, "child")
+    expected_lock_path = ProjectLock.lock_path_for_test("bad-root", bad_root)
+    File.write!(blocked_parent, "file")
+
+    assert {:error, {:project_lock_unavailable, "bad-root", ^expected_lock_path, :enotdir}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :BadRoot),
+                   project_slug: "bad-root",
+                   lock_root: bad_root
+                 )
+               )
+             end)
+  end
+
+  test "formats duplicate start messages with optional details" do
+    message =
+      ProjectLock.duplicate_start_message(%{
+        project_slug: "project-detail",
+        hostname: "host-detail",
+        details: "owner metadata is unavailable"
+      })
+
+    assert message ==
+             "another Symphony process is already serving Linear project project-detail on host-detail; owner metadata is unavailable"
+  end
+
+  test "start_link/0 follows the current workflow config" do
+    with_memory_workflow(fn ->
+      assert {:ok, pid} = ProjectLock.start_link()
+      assert %{lock_path: nil, metadata_path: nil, owner: nil} = :sys.get_state(pid)
+      GenServer.stop(pid)
+    end)
+  end
+
+  test "returns ok for terminate fallback clauses" do
+    assert :ok = ProjectLock.terminate(:normal, :unknown)
+    assert :ok = ProjectLock.terminate(:normal, %{lock_path: "/tmp/lock", metadata_path: nil, owner: nil})
+  end
+
+  test "cleans up the lock directory when owner metadata cannot be encoded", %{lock_root: lock_root} do
+    assert {:error, {:project_lock_unavailable, "encode-error", lock_path, %Protocol.UndefinedError{}}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :EncodeError),
+                   project_slug: "encode-error",
+                   lock_root: lock_root,
+                   workflow_path: {:not, "json"}
+                 )
+               )
+             end)
+
+    refute File.exists?(lock_path)
+  end
+
+  test "surfaces lock-path creation failures after the root already exists", %{lock_root: lock_root} do
+    File.chmod!(lock_root, 0o500)
+
+    on_exit(fn ->
+      File.chmod!(lock_root, 0o700)
+    end)
+
+    assert {:error, {:project_lock_unavailable, "mkdir-failure", _lock_path, reason}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :MkdirFailure),
+                   project_slug: "mkdir-failure",
+                   lock_root: lock_root
+                 )
+               )
+             end)
+
+    assert reason in [:eacces, :eperm]
+  end
+
+  test "surfaces stale-lock cleanup failures when the lock cannot be removed", %{lock_root: lock_root} do
+    lock_path = ProjectLock.lock_path_for_test("stale-remove-failure", lock_root)
+    File.mkdir_p!(lock_path)
+
+    File.write!(
+      Path.join(lock_path, "owner.json"),
+      Jason.encode!(%{
+        instance_id: "stale-owner",
+        project_slug: "stale-remove-failure",
+        hostname: "old-host",
+        pid: 99_999,
+        workflow_path: "/tmp/stale-workflow.md",
+        cwd: "/tmp/stale-workspace",
+        started_at: "2026-02-27T22:30:00Z"
+      })
+    )
+
+    File.chmod!(lock_root, 0o500)
+
+    on_exit(fn ->
+      File.chmod!(lock_root, 0o700)
+    end)
+
+    assert {:error, {:project_lock_unavailable, "stale-remove-failure", ^lock_path, reason}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :StaleRemoveFailure),
+                   project_slug: "stale-remove-failure",
+                   lock_root: lock_root,
+                   pid_alive?: fn _pid -> false end
+                 )
+               )
+             end)
+
+    assert reason in [:eacces, :eperm]
+  end
+
+  test "logs a warning when releasing the lock cannot remove the directory", %{lock_root: lock_root} do
+    lock_path = ProjectLock.lock_path_for_test("release-warning", lock_root)
+    metadata_path = Path.join(lock_path, "owner.json")
+
+    owner = %{
+      instance_id: "owner-release-warning",
+      project_slug: "release-warning",
+      hostname: "test-host",
+      pid: 12_345,
+      workflow_path: "/tmp/WORKFLOW.md",
+      cwd: "/tmp/workspace",
+      started_at: "2026-02-27T22:30:00Z",
+      lock_path: lock_path
+    }
+
+    File.mkdir_p!(lock_path)
+    File.write!(metadata_path, Jason.encode!(owner))
+    File.chmod!(lock_root, 0o500)
+
+    on_exit(fn ->
+      File.chmod!(lock_root, 0o700)
+    end)
+
+    log =
+      capture_log(fn ->
+        assert :ok =
+                 ProjectLock.terminate(:normal, %{
+                   lock_path: lock_path,
+                   metadata_path: metadata_path,
+                   owner: owner
+                 })
+      end)
+
+    assert log =~ "Failed to release project lock #{lock_path}"
+  end
+
+  test "treats lock owners without a pid as active and omits pid details", %{lock_root: lock_root} do
+    lock_path = ProjectLock.lock_path_for_test("owner-without-pid", lock_root)
+    File.mkdir_p!(lock_path)
+
+    File.write!(
+      Path.join(lock_path, "owner.json"),
+      Jason.encode!(%{
+        instance_id: "owner-without-pid",
+        project_slug: "owner-without-pid",
+        hostname: "no-pid-host",
+        workflow_path: "/tmp/no-pid-workflow.md",
+        cwd: "/tmp/no-pid-workspace",
+        started_at: "2026-02-27T22:30:00Z"
+      })
+    )
+
+    assert {:error, {:project_already_running, owner}} =
+             trap_start_link(fn ->
+               ProjectLock.start_link(
+                 project_lock_opts(
+                   name: Module.concat(__MODULE__, :OwnerWithoutPid),
+                   project_slug: "owner-without-pid",
+                   lock_root: lock_root
+                 )
+               )
+             end)
+
+    assert owner.pid == nil
+    refute ProjectLock.duplicate_start_message(owner) =~ "(pid "
+  end
+
+  test "normalizes invalid configured pids to nil in lock state", %{lock_root: lock_root} do
+    assert {:ok, pid} =
+             ProjectLock.start_link(
+               project_lock_opts(
+                 name: Module.concat(__MODULE__, :InvalidPid),
+                 project_slug: "invalid-pid",
+                 lock_root: lock_root,
+                 os_pid: "not-a-pid"
+               )
+             )
+
+    assert %{owner: %{pid: nil}} = :sys.get_state(pid)
+    GenServer.stop(pid)
+  end
+
+  test "normalizes empty project-slug prefixes to a generic lock directory name", %{lock_root: lock_root} do
+    basename =
+      ProjectLock.lock_path_for_test("!!!", lock_root)
+      |> Path.basename()
+
+    assert String.starts_with?(basename, "project-")
+  end
+
+  test "hostname_for_test falls back when hostname lookup fails" do
+    assert ProjectLock.hostname_for_test(fn -> :error end) == "unknown-host"
+  end
+
+  test "os_pid_alive_for_test handles missing kill binary, success, failure, and invalid input" do
+    assert ProjectLock.os_pid_alive_for_test(12_345, fn "kill" -> nil end, fn _, _, _ -> {"", 0} end) == :unknown
+
+    assert ProjectLock.os_pid_alive_for_test(
+             12_345,
+             fn "kill" -> "/usr/bin/kill" end,
+             fn "/usr/bin/kill", ["-0", "12345"], stderr_to_stdout: true -> {"", 0} end
+           ) == true
+
+    assert ProjectLock.os_pid_alive_for_test(
+             12_345,
+             fn "kill" -> "/usr/bin/kill" end,
+             fn "/usr/bin/kill", ["-0", "12345"], stderr_to_stdout: true -> {"", 1} end
+           ) == false
+
+    assert ProjectLock.os_pid_alive_for_test("invalid") == :unknown
+  end
+
+  defp project_lock_opts(overrides) do
+    Keyword.merge(
+      [
+        tracker_kind: "linear",
+        workflow_path: "/tmp/WORKFLOW.md",
+        cwd: "/tmp/workspace",
+        hostname: "test-host",
+        started_at: "2026-02-27T22:30:00Z",
+        pid_alive?: fn _pid -> false end
+      ],
+      overrides
+    )
+  end
+
+  defp temporary_child_spec(id, opts) do
+    %{
+      id: id,
+      start: {ProjectLock, :start_link, [opts]},
+      restart: :temporary
+    }
+  end
+
+  defp trap_start_link(fun) do
+    previous_flag = Process.flag(:trap_exit, true)
+
+    try do
+      fun.()
+    after
+      Process.flag(:trap_exit, previous_flag)
+    end
+  end
+
+  defp with_memory_workflow(fun) do
+    original_path = Workflow.workflow_file_path()
+
+    workflow_root =
+      Path.join(
+        System.tmp_dir!(),
+        "project-lock-workflow-#{System.unique_integer([:positive])}"
+      )
+
+    workflow_path = Path.join(workflow_root, "WORKFLOW.md")
+
+    File.mkdir_p!(workflow_root)
+
+    File.write!(
+      workflow_path,
+      """
+      ---
+      tracker:
+        kind: memory
+      ---
+      Test prompt
+      """
+    )
+
+    Workflow.set_workflow_file_path(workflow_path)
+
+    try do
+      fun.()
+    after
+      Workflow.set_workflow_file_path(original_path)
+      File.rm_rf(workflow_root)
+    end
+  end
+end


### PR DESCRIPTION
#### Context

Starting two Symphony instances against the same Linear project currently succeeds, so both processes can serve the same project concurrently.

#### TL;DR

*Add a project-scoped startup lock so only one Symphony process can serve a Linear project at a time.*

#### Summary

- Add `SymphonyElixir.ProjectLock` to acquire a project-scoped startup lock before the orchestrator starts
- Record owner metadata, reject duplicate same-project startups, and reclaim stale locks when the owner PID is gone
- Improve CLI startup errors and add focused coverage for lock behavior and duplicate-start reporting

#### Alternatives

- Use an external lock service, but that adds infrastructure for a host-local duplicate-start problem
- Rely on workflow-path locking alone, but the requirement is uniqueness per Linear project rather than per file path

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/project_lock_test.exs test/symphony_elixir/cli_test.exs`
- [x] From `elixir/`, start one CLI-backed Symphony process, confirm a second startup against the same `WORKFLOW.md` fails with the duplicate-owner message, then stop the proof process
