### PR TITLE
Add coverage for five low-hanging Elixir modules

### DIFF
--- a/elixir/lib/symphony_elixir/workflow.ex
+++ b/elixir/lib/symphony_elixir/workflow.ex
@@ -106,7 +106,6 @@ defmodule SymphonyElixir.Workflow do
       {:ok, %{}}
     else
       case YamlElixir.read_from_string(yaml) do
-        {:ok, %{} = decoded} -> {:ok, decoded}
         {:ok, decoded} when is_map(decoded) -> {:ok, decoded}
         {:ok, _} -> {:error, :workflow_front_matter_not_a_map}
         {:error, reason} -> {:error, reason}

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -12,11 +12,7 @@ defmodule SymphonyElixir.MixProject do
           threshold: 100
         ],
         ignore_modules: [
-          Mix.Tasks.Specs.Check,
-          SymphonyElixir,
-          SymphonyElixir.Application,
           SymphonyElixir.Config,
-          SymphonyElixir.Workflow,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,
@@ -25,7 +21,6 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.CLI,
           SymphonyElixir.Codex.AppServer,
           SymphonyElixir.Codex.DynamicTool,
-          SymphonyElixir.PromptBuilder,
           SymphonyElixir.StatusDashboard,
           SymphonyElixir.LogFile,
           SymphonyElixir.Workspace

--- a/elixir/test/mix/tasks/specs_check_task_test.exs
+++ b/elixir/test/mix/tasks/specs_check_task_test.exs
@@ -1,0 +1,112 @@
+defmodule Mix.Tasks.Specs.CheckTaskTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Specs.Check
+
+  setup do
+    Mix.Task.reenable("specs.check")
+    :ok
+  end
+
+  test "uses the default lib path when all public functions have specs" do
+    in_temp_project(fn ->
+      write_module!("lib/sample.ex", """
+      defmodule Sample do
+        @spec ok(term()) :: term()
+        def ok(arg), do: arg
+      end
+      """)
+
+      output =
+        capture_io(fn ->
+          assert :ok = Check.run([])
+        end)
+
+      assert output =~ "specs.check: all public functions have @spec or exemption"
+    end)
+  end
+
+  test "raises when an explicit path contains missing specs" do
+    in_temp_project(fn ->
+      write_module!("src/sample.ex", """
+      defmodule Sample do
+        def missing(arg), do: arg
+      end
+      """)
+
+      error_output =
+        capture_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/specs.check failed with 1 missing @spec declaration/, fn ->
+            Check.run(["--paths", "src"])
+          end
+        end)
+
+      assert error_output =~ "src/sample.ex:2 missing @spec for Sample.missing/1"
+    end)
+  end
+
+  test "loads exemptions from a file and ignores comments and blank lines" do
+    in_temp_project(fn ->
+      write_module!("lib/sample.ex", """
+      defmodule Sample do
+        def legacy(arg), do: arg
+      end
+      """)
+
+      File.mkdir_p!("config")
+
+      File.write!("config/specs_exemptions.txt", """
+      # existing exemptions
+
+      Sample.legacy/1
+      """)
+
+      output =
+        capture_io(fn ->
+          assert :ok = Check.run(["--paths", "lib", "--exemptions-file", "config/specs_exemptions.txt"])
+        end)
+
+      assert output =~ "specs.check: all public functions have @spec or exemption"
+    end)
+  end
+
+  test "treats a missing exemptions file as empty" do
+    in_temp_project(fn ->
+      write_module!("lib/sample.ex", """
+      defmodule Sample do
+        @spec ok(term()) :: term()
+        def ok(arg), do: arg
+      end
+      """)
+
+      output =
+        capture_io(fn ->
+          assert :ok = Check.run(["--exemptions-file", "config/missing.txt"])
+        end)
+
+      assert output =~ "specs.check: all public functions have @spec or exemption"
+    end)
+  end
+
+  defp in_temp_project(fun) do
+    root = Path.join(System.tmp_dir!(), "specs-check-task-test-#{System.unique_integer([:positive, :monotonic])}")
+    original_cwd = File.cwd!()
+
+    File.rm_rf!(root)
+    File.mkdir_p!(root)
+
+    try do
+      File.cd!(root, fun)
+    after
+      File.cd!(original_cwd)
+      File.rm_rf!(root)
+    end
+  end
+
+  defp write_module!(path, source) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, source)
+  end
+end

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -118,6 +118,53 @@ defmodule SymphonyElixir.CoreTest do
     assert Workflow.workflow_file_path() == app_workflow_path
   end
 
+  test "workflow load accepts prompt-only files without front matter" do
+    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "PROMPT_ONLY_WORKFLOW.md")
+    File.write!(workflow_path, "Prompt only\n")
+
+    assert {:ok, %{config: %{}, prompt: "Prompt only", prompt_template: "Prompt only"}} =
+             Workflow.load(workflow_path)
+  end
+
+  test "workflow load accepts unterminated front matter with an empty prompt" do
+    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "UNTERMINATED_WORKFLOW.md")
+    File.write!(workflow_path, "---\ntracker:\n  kind: linear\n")
+
+    assert {:ok, %{config: %{"tracker" => %{"kind" => "linear"}}, prompt: "", prompt_template: ""}} =
+             Workflow.load(workflow_path)
+  end
+
+  test "workflow load rejects non-map front matter" do
+    workflow_path = Path.join(Path.dirname(Workflow.workflow_file_path()), "INVALID_FRONT_MATTER_WORKFLOW.md")
+    File.write!(workflow_path, "---\n- not-a-map\n---\nPrompt body\n")
+
+    assert {:error, :workflow_front_matter_not_a_map} = Workflow.load(workflow_path)
+  end
+
+  test "SymphonyElixir.start_link delegates to the orchestrator" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [])
+    orchestrator_pid = Process.whereis(SymphonyElixir.Orchestrator)
+
+    on_exit(fn ->
+      if is_nil(Process.whereis(SymphonyElixir.Orchestrator)) do
+        case Supervisor.restart_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+        end
+      end
+    end)
+
+    if is_pid(orchestrator_pid) do
+      assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
+    end
+
+    assert {:ok, pid} = SymphonyElixir.start_link()
+    assert Process.whereis(SymphonyElixir.Orchestrator) == pid
+
+    GenServer.stop(pid)
+  end
+
   test "linear issue state reconciliation fetch with no running issues is a no-op" do
     assert {:ok, []} = Client.fetch_issue_states_by_ids([])
   end
@@ -413,6 +460,27 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "Ticket MT-697"
     assert prompt =~ "created=2026-02-26T18:06:48Z"
     assert prompt =~ "updated=2026-02-26T18:07:03Z"
+  end
+
+  test "prompt builder normalizes nested date-like values, maps, and structs in issue fields" do
+    write_workflow_file!(Workflow.workflow_file_path(), prompt: "Ticket {{ issue.identifier }}")
+
+    issue = %Issue{
+      identifier: "MT-701",
+      title: "Serialize nested values",
+      description: "Prompt builder should normalize nested terms",
+      state: "Todo",
+      url: "https://example.org/issues/MT-701",
+      labels: [
+        ~N[2026-02-27 12:34:56],
+        ~D[2026-02-28],
+        ~T[12:34:56],
+        %{phase: "test"},
+        URI.parse("https://example.org/issues/MT-701")
+      ]
+    }
+
+    assert PromptBuilder.build_prompt(issue) == "Ticket MT-701"
   end
 
   test "prompt builder uses strict variable rendering" do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1087,7 +1087,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     end)
 
     StatusDashboard.notify_update(dashboard_name)
-    assert_receive {:render, first_render_ms, _content}, 200
+    assert_receive {:render, first_render_ms, _content}, 500
 
     :sys.replace_state(pid, fn state ->
       %{state | last_snapshot_fingerprint: :force_next_change, last_rendered_content: nil}
@@ -1096,7 +1096,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     StatusDashboard.notify_update(dashboard_name)
     StatusDashboard.notify_update(dashboard_name)
 
-    assert_receive {:render, second_render_ms, _content}, 200
+    assert_receive {:render, second_render_ms, _content}, 500
     assert second_render_ms > first_render_ms
     refute_receive {:render, _third_render_ms, _content}, 60
   end

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1068,6 +1068,20 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
   test "status dashboard coalesces rapid updates to one render per interval" do
     dashboard_name = Module.concat(__MODULE__, :RenderDashboard)
     parent = self()
+    orchestrator_pid = Process.whereis(SymphonyElixir.Orchestrator)
+
+    on_exit(fn ->
+      if is_nil(Process.whereis(SymphonyElixir.Orchestrator)) do
+        case Supervisor.restart_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+        end
+      end
+    end)
+
+    if is_pid(orchestrator_pid) do
+      assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, SymphonyElixir.Orchestrator)
+    end
 
     {:ok, pid} =
       StatusDashboard.start_link(
@@ -1087,7 +1101,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     end)
 
     StatusDashboard.notify_update(dashboard_name)
-    assert_receive {:render, first_render_ms, _content}, 500
+    assert_receive {:render, first_render_ms, _content}, 200
 
     :sys.replace_state(pid, fn state ->
       %{state | last_snapshot_fingerprint: :force_next_change, last_rendered_content: nil}
@@ -1096,7 +1110,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     StatusDashboard.notify_update(dashboard_name)
     StatusDashboard.notify_update(dashboard_name)
 
-    assert_receive {:render, second_render_ms, _content}, 500
+    assert_receive {:render, second_render_ms, _content}, 200
     assert second_render_ms > first_render_ms
     refute_receive {:render, _third_render_ms, _content}, 60
   end


### PR DESCRIPTION
#### Context

MT-715 asks us to remove the lowest-hanging ignored modules from
`elixir/mix.exs` and keep the Elixir app at 100% coverage.

#### TL;DR

*Remove five easy modules from the coverage ignore list and add the
tests needed to keep total coverage at 100%.*

#### Summary

- Remove `Mix.Tasks.Specs.Check`, `SymphonyElixir`,
  `SymphonyElixir.Application`, `SymphonyElixir.Workflow`, and
  `SymphonyElixir.PromptBuilder` from the coverage ignore list.
- Add tests for workflow loading edge cases, the `SymphonyElixir`
  wrapper entrypoint, nested prompt serialization, and the
  `specs.check` mix task.
- Make the dashboard coalescing test deterministic by isolating it
  from the shared orchestrator instead of widening its timeout.

#### Alternatives

- Leave the five modules ignored and only document the gap. That does
  not satisfy MT-715.
- Target larger ignored modules like `Workspace` or `CLI` first. They
  need more setup-heavy coverage for less ticket progress.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mix test test/symphony_elixir/core_test.exs test/mix/tasks/specs_check_task_test.exs`
- [x] `cd elixir && mix test test/symphony_elixir/orchestrator_status_test.exs:1068`