### PR TITLE
Make Codex policies configurable and handle non-interactive prompts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -417,10 +417,24 @@ Fields:
 
 Fields:
 
+For Codex-owned config values such as `approval_policy`, `thread_sandbox`, and
+`turn_sandbox_policy`, supported values are defined by the targeted Codex app-server version.
+Implementors should treat them as pass-through Codex config values rather than relying on a
+hand-maintained enum in this spec. To inspect the installed Codex schema, run
+`codex app-server generate-json-schema --out <dir>` and inspect the relevant definitions referenced
+by `v2/ThreadStartParams.json` and `v2/TurnStartParams.json`. Implementations may validate these
+fields locally if they want stricter startup checks.
+
 - `command` (string shell command)
   - Default: `codex app-server`
   - The runtime launches this command via `bash -lc` in the workspace directory.
   - The launched process must speak a compatible app-server protocol over stdio.
+- `approval_policy` (Codex `AskForApproval` value)
+  - Default: implementation-defined.
+- `thread_sandbox` (Codex `SandboxMode` value)
+  - Default: implementation-defined.
+- `turn_sandbox_policy` (Codex `SandboxPolicy` value)
+  - Default: implementation-defined.
 - `turn_timeout_ms` (integer)
   - Default: `3600000` (1 hour)
 - `read_timeout_ms` (integer)
@@ -555,6 +569,9 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.max_concurrent_agents_by_state`: map of positive integers, default `{}`
 - `codex.command`: shell command string, default `codex app-server`
+- `codex.approval_policy`: Codex `AskForApproval` value, default implementation-defined
+- `codex.thread_sandbox`: Codex `SandboxMode` value, default implementation-defined
+- `codex.turn_sandbox_policy`: Codex `SandboxPolicy` value, default implementation-defined
 - `codex.turn_timeout_ms`: integer, default `3600000`
 - `codex.read_timeout_ms`: integer, default `5000`
 - `codex.stall_timeout_ms`: integer, default `300000`

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -81,6 +81,14 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used.
+- Safer Codex defaults are used when policy fields are omitted:
+  - `codex.approval_policy` defaults to `{"reject":{"sandbox_approval":true,"rules":true,"mcp_elicitations":true}}`
+  - `codex.thread_sandbox` defaults to `workspace-write`
+  - `codex.turn_sandbox_policy` defaults to a `workspaceWrite` policy rooted at the current issue workspace
+- Supported `codex.approval_policy` values depend on the targeted Codex app-server version. In the current local Codex schema, string values include `untrusted`, `on-failure`, `on-request`, and `never`, and object-form `reject` is also supported.
+- Supported `codex.thread_sandbox` values: `read-only`, `workspace-write`, `danger-full-access`.
+- Supported `codex.turn_sandbox_policy.type` values: `dangerFullAccess`, `readOnly`,
+  `externalSandbox`, `workspaceWrite`.
 - `agent.max_turns` caps how many back-to-back Codex turns Symphony will run in a single agent
   invocation when a turn completes normally but the issue is still in an active state. Default: `20`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -29,7 +29,8 @@ agent:
   max_concurrent_agents: 10
   max_turns: 20
 codex:
-  command: codex --sandbox danger-full-access --ask-for-approval never --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  approval_policy: "never"
 ---
 
 You are working on a Linear ticket `{{ issue.identifier }}`

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -31,6 +31,9 @@ agent:
 codex:
   command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
   approval_policy: "never"
+  thread_sandbox: "danger-full-access"
+  turn_sandbox_policy:
+    type: dangerFullAccess
 ---
 
 You are working on a Linear ticket `{{ issue.identifier }}`

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -11,13 +11,14 @@ defmodule SymphonyElixir.Codex.AppServer do
   @turn_start_id 3
   @port_line_bytes 1_048_576
   @max_stream_log_bytes 1_000
-  @approval_policy "never"
-  @thread_sandbox "danger-full-access"
-  @turn_sandbox_policy %{"type" => "dangerFullAccess"}
 
   @type session :: %{
           port: port(),
           metadata: map(),
+          approval_policy: String.t() | map(),
+          auto_approve_requests: boolean(),
+          thread_sandbox: String.t(),
+          turn_sandbox_policy: map(),
           thread_id: String.t(),
           workspace: Path.t()
         }
@@ -40,16 +41,20 @@ defmodule SymphonyElixir.Codex.AppServer do
       metadata = port_metadata(port)
       expanded_workspace = Path.expand(workspace)
 
-      case do_start_session(port, expanded_workspace) do
-        {:ok, thread_id} ->
-          {:ok,
-           %{
-             port: port,
-             metadata: metadata,
-             thread_id: thread_id,
-             workspace: expanded_workspace
-           }}
-
+      with {:ok, session_policies} <- session_policies(expanded_workspace),
+           {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_policies) do
+        {:ok,
+         %{
+           port: port,
+           metadata: metadata,
+           approval_policy: session_policies.approval_policy,
+           auto_approve_requests: session_policies.approval_policy == "never",
+           thread_sandbox: session_policies.thread_sandbox,
+           turn_sandbox_policy: session_policies.turn_sandbox_policy,
+           thread_id: thread_id,
+           workspace: expanded_workspace
+         }}
+      else
         {:error, reason} ->
           stop_port(port)
           {:error, reason}
@@ -58,7 +63,20 @@ defmodule SymphonyElixir.Codex.AppServer do
   end
 
   @spec run_turn(session(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
-  def run_turn(%{port: port, metadata: metadata, thread_id: thread_id, workspace: workspace}, prompt, issue, opts \\ []) do
+  def run_turn(
+        %{
+          port: port,
+          metadata: metadata,
+          approval_policy: approval_policy,
+          auto_approve_requests: auto_approve_requests,
+          turn_sandbox_policy: turn_sandbox_policy,
+          thread_id: thread_id,
+          workspace: workspace
+        },
+        prompt,
+        issue,
+        opts \\ []
+      ) do
     on_message = Keyword.get(opts, :on_message, &default_on_message/1)
 
     tool_executor =
@@ -66,7 +84,7 @@ defmodule SymphonyElixir.Codex.AppServer do
         DynamicTool.execute(tool, arguments)
       end)
 
-    case start_turn(port, thread_id, prompt, issue, workspace) do
+    case start_turn(port, thread_id, prompt, issue, workspace, approval_policy, turn_sandbox_policy) do
       {:ok, turn_id} ->
         session_id = "#{thread_id}-#{turn_id}"
         Logger.info("Codex session started for #{issue_context(issue)} session_id=#{session_id}")
@@ -82,7 +100,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           metadata
         )
 
-        case await_turn_completion(port, on_message, tool_executor) do
+        case await_turn_completion(port, on_message, tool_executor, auto_approve_requests) do
           {:ok, result} ->
             Logger.info("Codex session completed for #{issue_context(issue)} session_id=#{session_id}")
 
@@ -197,20 +215,24 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp do_start_session(port, workspace) do
+  defp session_policies(workspace) do
+    Config.codex_runtime_settings(workspace)
+  end
+
+  defp do_start_session(port, workspace, session_policies) do
     case send_initialize(port) do
-      :ok -> start_thread(port, workspace)
+      :ok -> start_thread(port, workspace, session_policies)
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp start_thread(port, workspace) do
+  defp start_thread(port, workspace, %{approval_policy: approval_policy, thread_sandbox: thread_sandbox}) do
     send_message(port, %{
       "method" => "thread/start",
       "id" => @thread_start_id,
       "params" => %{
-        "approvalPolicy" => @approval_policy,
-        "sandbox" => @thread_sandbox,
+        "approvalPolicy" => approval_policy,
+        "sandbox" => thread_sandbox,
         "cwd" => Path.expand(workspace),
         "dynamicTools" => DynamicTool.tool_specs()
       }
@@ -228,7 +250,7 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp start_turn(port, thread_id, prompt, issue, workspace) do
+  defp start_turn(port, thread_id, prompt, issue, workspace, approval_policy, turn_sandbox_policy) do
     send_message(port, %{
       "method" => "turn/start",
       "id" => @turn_start_id,
@@ -242,8 +264,8 @@ defmodule SymphonyElixir.Codex.AppServer do
         ],
         "cwd" => Path.expand(workspace),
         "title" => "#{issue.identifier}: #{issue.title}",
-        "approvalPolicy" => @approval_policy,
-        "sandboxPolicy" => @turn_sandbox_policy
+        "approvalPolicy" => approval_policy,
+        "sandboxPolicy" => turn_sandbox_policy
       }
     })
 
@@ -253,18 +275,25 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp await_turn_completion(port, on_message, tool_executor) do
-    receive_loop(port, on_message, Config.codex_turn_timeout_ms(), "", tool_executor)
+  defp await_turn_completion(port, on_message, tool_executor, auto_approve_requests) do
+    receive_loop(port, on_message, Config.codex_turn_timeout_ms(), "", tool_executor, auto_approve_requests)
   end
 
-  defp receive_loop(port, on_message, timeout_ms, pending_line, tool_executor) do
+  defp receive_loop(port, on_message, timeout_ms, pending_line, tool_executor, auto_approve_requests) do
     receive do
       {^port, {:data, {:eol, chunk}}} ->
         complete_line = pending_line <> to_string(chunk)
-        handle_incoming(port, on_message, complete_line, timeout_ms, tool_executor)
+        handle_incoming(port, on_message, complete_line, timeout_ms, tool_executor, auto_approve_requests)
 
       {^port, {:data, {:noeol, chunk}}} ->
-        receive_loop(port, on_message, timeout_ms, pending_line <> to_string(chunk), tool_executor)
+        receive_loop(
+          port,
+          on_message,
+          timeout_ms,
+          pending_line <> to_string(chunk),
+          tool_executor,
+          auto_approve_requests
+        )
 
       {^port, {:exit_status, status}} ->
         {:error, {:port_exit, status}}
@@ -274,7 +303,7 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp handle_incoming(port, on_message, data, timeout_ms, tool_executor) do
+  defp handle_incoming(port, on_message, data, timeout_ms, tool_executor, auto_approve_requests) do
     payload_string = to_string(data)
 
     case Jason.decode(payload_string) do
@@ -308,7 +337,16 @@ defmodule SymphonyElixir.Codex.AppServer do
 
       {:ok, %{"method" => method} = payload}
       when is_binary(method) ->
-        handle_turn_method(port, on_message, payload, payload_string, method, timeout_ms, tool_executor)
+        handle_turn_method(
+          port,
+          on_message,
+          payload,
+          payload_string,
+          method,
+          timeout_ms,
+          tool_executor,
+          auto_approve_requests
+        )
 
       {:ok, payload} ->
         emit_message(
@@ -321,7 +359,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           metadata_from_message(port, payload)
         )
 
-        receive_loop(port, on_message, timeout_ms, "", tool_executor)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
 
       {:error, _reason} ->
         log_non_json_stream_line(payload_string, "turn stream")
@@ -336,7 +374,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           metadata_from_message(port, %{raw: payload_string})
         )
 
-        receive_loop(port, on_message, timeout_ms, "", tool_executor)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
     end
   end
 
@@ -353,7 +391,16 @@ defmodule SymphonyElixir.Codex.AppServer do
     )
   end
 
-  defp handle_turn_method(port, on_message, payload, payload_string, method, timeout_ms, tool_executor) do
+  defp handle_turn_method(
+         port,
+         on_message,
+         payload,
+         payload_string,
+         method,
+         timeout_ms,
+         tool_executor,
+         auto_approve_requests
+       ) do
     metadata = metadata_from_message(port, payload)
 
     case maybe_handle_approval_request(
@@ -363,7 +410,8 @@ defmodule SymphonyElixir.Codex.AppServer do
            payload_string,
            on_message,
            metadata,
-           tool_executor
+           tool_executor,
+           auto_approve_requests
          ) do
       :input_required ->
         emit_message(
@@ -376,7 +424,17 @@ defmodule SymphonyElixir.Codex.AppServer do
         {:error, {:turn_input_required, payload}}
 
       :approved ->
-        receive_loop(port, on_message, timeout_ms, "", tool_executor)
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+
+      :approval_required ->
+        emit_message(
+          on_message,
+          :approval_required,
+          %{payload: payload, raw: payload_string},
+          metadata
+        )
+
+        {:error, {:approval_required, payload}}
 
       :unhandled ->
         if needs_input?(method, payload) do
@@ -400,7 +458,7 @@ defmodule SymphonyElixir.Codex.AppServer do
           )
 
           Logger.debug("Codex notification: #{inspect(method)}")
-          receive_loop(port, on_message, timeout_ms, "", tool_executor)
+          receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
         end
     end
   end
@@ -412,18 +470,19 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload_string,
          on_message,
          metadata,
-         _tool_executor
+         _tool_executor,
+         auto_approve_requests
        ) do
-    send_message(port, %{"id" => id, "result" => %{"decision" => "acceptForSession"}})
-
-    emit_message(
+    approve_or_require(
+      port,
+      id,
+      "acceptForSession",
+      payload,
+      payload_string,
       on_message,
-      :approval_auto_approved,
-      %{payload: payload, raw: payload_string, decision: "acceptForSession"},
-      metadata
+      metadata,
+      auto_approve_requests
     )
-
-    :approved
   end
 
   defp maybe_handle_approval_request(
@@ -433,7 +492,8 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload_string,
          on_message,
          metadata,
-         tool_executor
+         tool_executor,
+         _auto_approve_requests
        ) do
     tool_name = tool_call_name(params)
     arguments = tool_call_arguments(params)
@@ -464,18 +524,19 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload_string,
          on_message,
          metadata,
-         _tool_executor
+         _tool_executor,
+         auto_approve_requests
        ) do
-    send_message(port, %{"id" => id, "result" => %{"decision" => "approved_for_session"}})
-
-    emit_message(
+    approve_or_require(
+      port,
+      id,
+      "approved_for_session",
+      payload,
+      payload_string,
       on_message,
-      :approval_auto_approved,
-      %{payload: payload, raw: payload_string, decision: "approved_for_session"},
-      metadata
+      metadata,
+      auto_approve_requests
     )
-
-    :approved
   end
 
   defp maybe_handle_approval_request(
@@ -485,18 +546,19 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload_string,
          on_message,
          metadata,
-         _tool_executor
+         _tool_executor,
+         auto_approve_requests
        ) do
-    send_message(port, %{"id" => id, "result" => %{"decision" => "approved_for_session"}})
-
-    emit_message(
+    approve_or_require(
+      port,
+      id,
+      "approved_for_session",
+      payload,
+      payload_string,
       on_message,
-      :approval_auto_approved,
-      %{payload: payload, raw: payload_string, decision: "approved_for_session"},
-      metadata
+      metadata,
+      auto_approve_requests
     )
-
-    :approved
   end
 
   defp maybe_handle_approval_request(
@@ -506,30 +568,41 @@ defmodule SymphonyElixir.Codex.AppServer do
          payload_string,
          on_message,
          metadata,
-         _tool_executor
+         _tool_executor,
+         auto_approve_requests
        ) do
-    send_message(port, %{"id" => id, "result" => %{"decision" => "acceptForSession"}})
-
-    emit_message(
+    approve_or_require(
+      port,
+      id,
+      "acceptForSession",
+      payload,
+      payload_string,
       on_message,
-      :approval_auto_approved,
-      %{payload: payload, raw: payload_string, decision: "acceptForSession"},
-      metadata
+      metadata,
+      auto_approve_requests
     )
-
-    :approved
   end
 
   defp maybe_handle_approval_request(
-         _port,
+         port,
          "item/tool/requestUserInput",
-         _payload,
-         _payload_string,
-         _on_message,
-         _metadata,
-         _tool_executor
+         %{"id" => id, "params" => params} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
        ) do
-    :input_required
+    maybe_auto_answer_tool_request_user_input(
+      port,
+      id,
+      params,
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
   end
 
   defp maybe_handle_approval_request(
@@ -539,9 +612,141 @@ defmodule SymphonyElixir.Codex.AppServer do
          _payload_string,
          _on_message,
          _metadata,
-         _tool_executor
+         _tool_executor,
+         _auto_approve_requests
        ) do
     :unhandled
+  end
+
+  defp approve_or_require(
+         port,
+         id,
+         decision,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
+         true
+       ) do
+    send_message(port, %{"id" => id, "result" => %{"decision" => decision}})
+
+    emit_message(
+      on_message,
+      :approval_auto_approved,
+      %{payload: payload, raw: payload_string, decision: decision},
+      metadata
+    )
+
+    :approved
+  end
+
+  defp approve_or_require(
+         _port,
+         _id,
+         _decision,
+         _payload,
+         _payload_string,
+         _on_message,
+         _metadata,
+         false
+       ) do
+    :approval_required
+  end
+
+  defp maybe_auto_answer_tool_request_user_input(
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
+         true
+       ) do
+    case tool_request_user_input_approval_answers(params) do
+      {:ok, answers, decision} ->
+        send_message(port, %{"id" => id, "result" => %{"answers" => answers}})
+
+        emit_message(
+          on_message,
+          :approval_auto_approved,
+          %{payload: payload, raw: payload_string, decision: decision},
+          metadata
+        )
+
+        :approved
+
+      :error ->
+        :input_required
+    end
+  end
+
+  defp maybe_auto_answer_tool_request_user_input(
+         _port,
+         _id,
+         _params,
+         _payload,
+         _payload_string,
+         _on_message,
+         _metadata,
+         false
+       ) do
+    :input_required
+  end
+
+  defp tool_request_user_input_approval_answers(%{"questions" => questions}) when is_list(questions) do
+    answers =
+      Enum.reduce_while(questions, %{}, fn question, acc ->
+        case tool_request_user_input_approval_answer(question) do
+          {:ok, question_id, answer_label} ->
+            {:cont, Map.put(acc, question_id, %{"answers" => [answer_label]})}
+
+          :error ->
+            {:halt, :error}
+        end
+      end)
+
+    case answers do
+      :error -> :error
+      answer_map when map_size(answer_map) > 0 -> {:ok, answer_map, "Approve this Session"}
+      _ -> :error
+    end
+  end
+
+  defp tool_request_user_input_approval_answers(_params), do: :error
+
+  defp tool_request_user_input_approval_answer(%{"id" => question_id, "options" => options})
+       when is_binary(question_id) and is_list(options) do
+    case tool_request_user_input_approval_option_label(options) do
+      nil -> :error
+      answer_label -> {:ok, question_id, answer_label}
+    end
+  end
+
+  defp tool_request_user_input_approval_answer(_question), do: :error
+
+  defp tool_request_user_input_approval_option_label(options) do
+    options
+    |> Enum.map(&tool_request_user_input_option_label/1)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      labels ->
+        Enum.find(labels, &(&1 == "Approve this Session")) ||
+          Enum.find(labels, &(&1 == "Approve Once")) ||
+          Enum.find(labels, &approval_option_label?/1)
+    end
+  end
+
+  defp tool_request_user_input_option_label(%{"label" => label}) when is_binary(label), do: label
+  defp tool_request_user_input_option_label(_option), do: nil
+
+  defp approval_option_label?(label) when is_binary(label) do
+    normalized_label =
+      label
+      |> String.trim()
+      |> String.downcase()
+
+    String.starts_with?(normalized_label, "approve") or String.starts_with?(normalized_label, "allow")
   end
 
   defp await_response(port, request_id) do

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -11,6 +11,7 @@ defmodule SymphonyElixir.Codex.AppServer do
   @turn_start_id 3
   @port_line_bytes 1_048_576
   @max_stream_log_bytes 1_000
+  @non_interactive_tool_input_answer "This is a non-interactive session. Operator input is unavailable."
 
   @type session :: %{
           port: port(),
@@ -677,21 +678,37 @@ defmodule SymphonyElixir.Codex.AppServer do
         :approved
 
       :error ->
-        :input_required
+        reply_with_non_interactive_tool_input_answer(
+          port,
+          id,
+          params,
+          payload,
+          payload_string,
+          on_message,
+          metadata
+        )
     end
   end
 
   defp maybe_auto_answer_tool_request_user_input(
-         _port,
-         _id,
-         _params,
-         _payload,
-         _payload_string,
-         _on_message,
-         _metadata,
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
          false
        ) do
-    :input_required
+    reply_with_non_interactive_tool_input_answer(
+      port,
+      id,
+      params,
+      payload,
+      payload_string,
+      on_message,
+      metadata
+    )
   end
 
   defp tool_request_user_input_approval_answers(%{"questions" => questions}) when is_list(questions) do
@@ -714,6 +731,59 @@ defmodule SymphonyElixir.Codex.AppServer do
   end
 
   defp tool_request_user_input_approval_answers(_params), do: :error
+
+  defp reply_with_non_interactive_tool_input_answer(
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata
+       ) do
+    case tool_request_user_input_unavailable_answers(params) do
+      {:ok, answers} ->
+        send_message(port, %{"id" => id, "result" => %{"answers" => answers}})
+
+        emit_message(
+          on_message,
+          :tool_input_auto_answered,
+          %{payload: payload, raw: payload_string, answer: @non_interactive_tool_input_answer},
+          metadata
+        )
+
+        :approved
+
+      :error ->
+        :input_required
+    end
+  end
+
+  defp tool_request_user_input_unavailable_answers(%{"questions" => questions}) when is_list(questions) do
+    answers =
+      Enum.reduce_while(questions, %{}, fn question, acc ->
+        case tool_request_user_input_question_id(question) do
+          {:ok, question_id} ->
+            {:cont, Map.put(acc, question_id, %{"answers" => [@non_interactive_tool_input_answer]})}
+
+          :error ->
+            {:halt, :error}
+        end
+      end)
+
+    case answers do
+      :error -> :error
+      answer_map when map_size(answer_map) > 0 -> {:ok, answer_map}
+      _ -> :error
+    end
+  end
+
+  defp tool_request_user_input_unavailable_answers(_params), do: :error
+
+  defp tool_request_user_input_question_id(%{"id" => question_id}) when is_binary(question_id),
+    do: {:ok, question_id}
+
+  defp tool_request_user_input_question_id(_question), do: :error
 
   defp tool_request_user_input_approval_answer(%{"id" => question_id, "options" => options})
        when is_binary(question_id) and is_list(options) do

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -27,10 +27,23 @@ defmodule SymphonyElixir.Config do
   @default_agent_max_turns 20
   @default_max_retry_backoff_ms 300_000
   @default_codex_command "codex app-server"
+  @default_codex_approval_policy %{
+    "reject" => %{
+      "sandbox_approval" => true,
+      "rules" => true,
+      "mcp_elicitations" => true
+    }
+  }
+  @default_codex_thread_sandbox "workspace-write"
   @default_server_host "127.0.0.1"
 
   @type workflow_payload :: Workflow.loaded_workflow()
   @type tracker_kind :: String.t() | nil
+  @type codex_runtime_settings :: %{
+          approval_policy: String.t() | map(),
+          thread_sandbox: String.t(),
+          turn_sandbox_policy: map()
+        }
   @type workspace_hooks :: %{
           after_create: String.t() | nil,
           before_run: String.t() | nil,
@@ -167,6 +180,30 @@ defmodule SymphonyElixir.Config do
     fetch_integer([["codex", "turn_timeout_ms"]], 3_600_000)
   end
 
+  @spec codex_approval_policy() :: String.t() | map()
+  def codex_approval_policy do
+    case resolve_codex_approval_policy() do
+      {:ok, approval_policy} -> approval_policy
+      {:error, _reason} -> @default_codex_approval_policy
+    end
+  end
+
+  @spec codex_thread_sandbox() :: String.t()
+  def codex_thread_sandbox do
+    case resolve_codex_thread_sandbox() do
+      {:ok, thread_sandbox} -> thread_sandbox
+      {:error, _reason} -> @default_codex_thread_sandbox
+    end
+  end
+
+  @spec codex_turn_sandbox_policy(Path.t() | nil) :: map()
+  def codex_turn_sandbox_policy(workspace \\ nil) do
+    case resolve_codex_turn_sandbox_policy(workspace) do
+      {:ok, turn_sandbox_policy} -> turn_sandbox_policy
+      {:error, _reason} -> default_codex_turn_sandbox_policy(workspace)
+    end
+  end
+
   @spec codex_read_timeout_ms() :: pos_integer()
   def codex_read_timeout_ms do
     fetch_integer([["codex", "read_timeout_ms"]], 5_000)
@@ -227,8 +264,23 @@ defmodule SymphonyElixir.Config do
     with {:ok, _workflow} <- current_workflow(),
          :ok <- require_tracker_kind(),
          :ok <- require_linear_token(),
-         :ok <- require_linear_project() do
+         :ok <- require_linear_project(),
+         :ok <- require_valid_codex_runtime_settings() do
       require_codex_command()
+    end
+  end
+
+  @spec codex_runtime_settings(Path.t() | nil) :: {:ok, codex_runtime_settings()} | {:error, term()}
+  def codex_runtime_settings(workspace \\ nil) do
+    with {:ok, approval_policy} <- resolve_codex_approval_policy(),
+         {:ok, thread_sandbox} <- resolve_codex_thread_sandbox(),
+         {:ok, turn_sandbox_policy} <- resolve_codex_turn_sandbox_policy(workspace) do
+      {:ok,
+       %{
+         approval_policy: approval_policy,
+         thread_sandbox: thread_sandbox,
+         turn_sandbox_policy: turn_sandbox_policy
+       }}
     end
   end
 
@@ -274,6 +326,13 @@ defmodule SymphonyElixir.Config do
       :ok
     else
       {:error, :missing_codex_command}
+    end
+  end
+
+  defp require_valid_codex_runtime_settings do
+    case codex_runtime_settings() do
+      {:ok, _settings} -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -347,6 +406,89 @@ defmodule SymphonyElixir.Config do
       value when is_map(value) -> value
       _ -> default
     end
+  end
+
+  defp resolve_codex_approval_policy do
+    case fetch_value([["codex", "approval_policy"]], :missing) do
+      :missing ->
+        {:ok, @default_codex_approval_policy}
+
+      nil ->
+        {:ok, @default_codex_approval_policy}
+
+      value when is_binary(value) ->
+        approval_policy = String.trim(value)
+
+        if approval_policy == "" do
+          {:error, {:invalid_codex_approval_policy, value}}
+        else
+          {:ok, approval_policy}
+        end
+
+      value when is_map(value) ->
+        {:ok, value}
+
+      value ->
+        {:error, {:invalid_codex_approval_policy, value}}
+    end
+  end
+
+  defp resolve_codex_thread_sandbox do
+    case fetch_value([["codex", "thread_sandbox"]], :missing) do
+      :missing ->
+        {:ok, @default_codex_thread_sandbox}
+
+      nil ->
+        {:ok, @default_codex_thread_sandbox}
+
+      value when is_binary(value) ->
+        thread_sandbox = String.trim(value)
+
+        if thread_sandbox == "" do
+          {:error, {:invalid_codex_thread_sandbox, value}}
+        else
+          {:ok, thread_sandbox}
+        end
+
+      value ->
+        {:error, {:invalid_codex_thread_sandbox, value}}
+    end
+  end
+
+  defp resolve_codex_turn_sandbox_policy(workspace) do
+    case fetch_value([["codex", "turn_sandbox_policy"]], :missing) do
+      :missing ->
+        {:ok, default_codex_turn_sandbox_policy(workspace)}
+
+      nil ->
+        {:ok, default_codex_turn_sandbox_policy(workspace)}
+
+      value when is_map(value) ->
+        {:ok, value}
+
+      value ->
+        {:error, {:invalid_codex_turn_sandbox_policy, {:unsupported_value, value}}}
+    end
+  end
+
+  defp default_codex_turn_sandbox_policy(workspace) do
+    writable_root =
+      cond do
+        is_binary(workspace) and String.trim(workspace) != "" ->
+          Path.expand(workspace)
+
+        true ->
+          Path.expand(workspace_root())
+      end
+
+    %{
+      "type" => "workspaceWrite",
+      "writableRoots" => [writable_root],
+      "readOnlyAccess" => %{"type" => "fullAccess"},
+      "networkAccess" => false,
+      "excludeTmpdirEnvVar" => false,
+      "excludeSlashTmp" => false
+    }
   end
 
   defp fetch_csv(paths, default) do

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -473,12 +473,10 @@ defmodule SymphonyElixir.Config do
 
   defp default_codex_turn_sandbox_policy(workspace) do
     writable_root =
-      cond do
-        is_binary(workspace) and String.trim(workspace) != "" ->
-          Path.expand(workspace)
-
-        true ->
-          Path.expand(workspace_root())
+      if is_binary(workspace) and String.trim(workspace) != "" do
+        Path.expand(workspace)
+      else
+        Path.expand(workspace_root())
       end
 
     %{

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -196,6 +196,18 @@ defmodule SymphonyElixir.Orchestrator do
         Logger.error("Codex command missing in WORKFLOW.md")
         state
 
+      {:error, {:invalid_codex_approval_policy, value}} ->
+        Logger.error("Invalid codex.approval_policy in WORKFLOW.md: #{inspect(value)}")
+        state
+
+      {:error, {:invalid_codex_thread_sandbox, value}} ->
+        Logger.error("Invalid codex.thread_sandbox in WORKFLOW.md: #{inspect(value)}")
+        state
+
+      {:error, {:invalid_codex_turn_sandbox_policy, reason}} ->
+        Logger.error("Invalid codex.turn_sandbox_policy in WORKFLOW.md: #{inspect(reason)}")
+        state
+
       {:error, {:missing_workflow_file, path, reason}} ->
         Logger.error("Missing WORKFLOW.md at #{path}: #{inspect(reason)}")
         state

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -1106,6 +1106,18 @@ defmodule SymphonyElixir.StatusDashboard do
     if is_binary(decision), do: "#{base}: #{decision}", else: base
   end
 
+  defp humanize_codex_event(:tool_input_auto_answered, message, payload) do
+    answer = map_value(message, ["answer", :answer])
+
+    base =
+      case humanize_codex_method("item/tool/requestUserInput", payload) do
+        nil -> "tool input auto-answered"
+        text -> "#{text} (auto-answered)"
+      end
+
+    if is_binary(answer), do: "#{base}: #{inline_text(answer)}", else: base
+  end
+
   defp humanize_codex_event(:tool_call_completed, _message, payload),
     do: humanize_dynamic_tool_event("dynamic tool call completed", payload)
 

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -94,6 +94,9 @@ defmodule SymphonyElixir.TestSupport do
           max_retry_backoff_ms: 300_000,
           max_concurrent_agents_by_state: %{},
           codex_command: "codex app-server",
+          codex_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
+          codex_thread_sandbox: "workspace-write",
+          codex_turn_sandbox_policy: nil,
           codex_turn_timeout_ms: 3_600_000,
           codex_read_timeout_ms: 5_000,
           codex_stall_timeout_ms: 300_000,
@@ -125,6 +128,9 @@ defmodule SymphonyElixir.TestSupport do
     max_retry_backoff_ms = Keyword.get(config, :max_retry_backoff_ms)
     max_concurrent_agents_by_state = Keyword.get(config, :max_concurrent_agents_by_state)
     codex_command = Keyword.get(config, :codex_command)
+    codex_approval_policy = Keyword.get(config, :codex_approval_policy)
+    codex_thread_sandbox = Keyword.get(config, :codex_thread_sandbox)
+    codex_turn_sandbox_policy = Keyword.get(config, :codex_turn_sandbox_policy)
     codex_turn_timeout_ms = Keyword.get(config, :codex_turn_timeout_ms)
     codex_read_timeout_ms = Keyword.get(config, :codex_read_timeout_ms)
     codex_stall_timeout_ms = Keyword.get(config, :codex_stall_timeout_ms)
@@ -161,6 +167,9 @@ defmodule SymphonyElixir.TestSupport do
         "  max_concurrent_agents_by_state: #{yaml_value(max_concurrent_agents_by_state)}",
         "codex:",
         "  command: #{yaml_value(codex_command)}",
+        "  approval_policy: #{yaml_value(codex_approval_policy)}",
+        "  thread_sandbox: #{yaml_value(codex_thread_sandbox)}",
+        "  turn_sandbox_policy: #{yaml_value(codex_turn_sandbox_policy)}",
         "  turn_timeout_ms: #{yaml_value(codex_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(codex_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(codex_stall_timeout_ms)}",

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -118,7 +118,70 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
-  test "app server auto-approves command execution approval requests" do
+  test "app server fails when command execution approval is required under safer defaults" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-approval-required-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-89")
+      codex_binary = Path.join(test_root, "fake-codex")
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      count=0
+      while IFS= read -r _line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-89"}}}'
+            ;;
+          3)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-89"}}}'
+            printf '%s\\n' '{"id":99,"method":"item/commandExecution/requestApproval","params":{"command":"gh pr view","cwd":"/tmp","reason":"need approval"}}'
+            ;;
+          *)
+            sleep 1
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-approval-required",
+        identifier: "MT-89",
+        title: "Approval required",
+        description: "Ensure safer defaults do not auto approve requests",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-89",
+        labels: ["backend"]
+      }
+
+      assert {:error, {:approval_required, payload}} =
+               AppServer.run(workspace, "Handle approval request", issue)
+
+      assert payload["method"] == "item/commandExecution/requestApproval"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server auto-approves command execution approval requests when approval policy is never" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -179,7 +242,8 @@ defmodule SymphonyElixir.AppServerTest do
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        codex_command: "#{codex_binary} app-server",
+        codex_approval_policy: "never"
       )
 
       issue = %Issue{
@@ -249,6 +313,171 @@ defmodule SymphonyElixir.AppServerTest do
                  false
                end
              end)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server auto-approves MCP tool approval prompts when approval policy is never" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-tool-user-input-auto-approve-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-717")
+      codex_binary = Path.join(test_root, "fake-codex")
+      trace_file = Path.join(test_root, "codex-tool-user-input-auto-approve.trace")
+      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+
+      on_exit(fn ->
+        if is_binary(previous_trace) do
+          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+        else
+          System.delete_env("SYMP_TEST_CODEx_TRACE")
+        end
+      end)
+
+      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-auto-approve.trace}"
+      count=0
+      while IFS= read -r line; do
+        count=$((count + 1))
+        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
+
+        case \"$count\" in
+          1)
+            printf '%s\\n' '{\"id\":1,\"result\":{}}'
+            ;;
+          2)
+            ;;
+          3)
+            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-717\"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-717\"}}}'
+            printf '%s\\n' '{\"id\":110,\"method\":\"item/tool/requestUserInput\",\"params\":{\"itemId\":\"call-717\",\"questions\":[{\"header\":\"Approve app tool call?\",\"id\":\"mcp_tool_call_approval_call-717\",\"isOther\":false,\"isSecret\":false,\"options\":[{\"description\":\"Run the tool and continue.\",\"label\":\"Approve Once\"},{\"description\":\"Run the tool and remember this choice for this session.\",\"label\":\"Approve this Session\"},{\"description\":\"Decline this tool call and continue.\",\"label\":\"Deny\"},{\"description\":\"Cancel this tool call\",\"label\":\"Cancel\"}],\"question\":\"The linear MCP server wants to run the tool \\\"Save issue\\\", which may modify or delete data. Allow this action?\"}],\"threadId\":\"thread-717\",\"turnId\":\"turn-717\"}}'
+            ;;
+          5)
+            printf '%s\\n' '{\"method\":\"turn/completed\"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server",
+        codex_approval_policy: "never"
+      )
+
+      issue = %Issue{
+        id: "issue-tool-user-input-auto-approve",
+        identifier: "MT-717",
+        title: "Auto approve MCP tool request user input",
+        description: "Ensure app tool approval prompts continue automatically",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-717",
+        labels: ["backend"]
+      }
+
+      assert {:ok, _result} = AppServer.run(workspace, "Handle tool approval prompt", issue)
+
+      trace = File.read!(trace_file)
+      lines = String.split(trace, "\n", trim: true)
+
+      assert Enum.any?(lines, fn line ->
+               if String.starts_with?(line, "JSON:") do
+                 payload =
+                   line
+                   |> String.trim_leading("JSON:")
+                   |> Jason.decode!()
+
+                 payload["id"] == 110 and
+                   get_in(payload, ["result", "answers", "mcp_tool_call_approval_call-717", "answers"]) ==
+                     ["Approve this Session"]
+               else
+                 false
+               end
+             end)
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server still fails closed for non-approval tool input prompts under approval policy never" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-tool-user-input-required-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-718")
+      codex_binary = Path.join(test_root, "fake-codex")
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      count=0
+      while IFS= read -r _line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            ;;
+          3)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-718"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-718"}}}'
+            printf '%s\\n' '{"id":111,"method":"item/tool/requestUserInput","params":{"itemId":"call-718","questions":[{"header":"Provide context","id":"freeform-718","isOther":false,"isSecret":false,"options":null,"question":"What comment should I post back to the issue?"}],"threadId":"thread-718","turnId":"turn-718"}}'
+            ;;
+          *)
+            sleep 1
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server",
+        codex_approval_policy: "never"
+      )
+
+      issue = %Issue{
+        id: "issue-tool-user-input-required",
+        identifier: "MT-718",
+        title: "Non approval tool input remains blocked",
+        description: "Ensure arbitrary tool prompts are not auto answered",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-718",
+        labels: ["backend"]
+      }
+
+      assert {:error, {:turn_input_required, payload}} =
+               AppServer.run(workspace, "Handle generic tool input", issue)
+
+      assert payload["method"] == "item/tool/requestUserInput"
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -417,7 +417,7 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
-  test "app server still fails closed for non-approval tool input prompts under approval policy never" do
+  test "app server sends a generic non-interactive answer for freeform tool input prompts" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -449,8 +449,12 @@ defmodule SymphonyElixir.AppServerTest do
             printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-718"}}}'
             printf '%s\\n' '{"id":111,"method":"item/tool/requestUserInput","params":{"itemId":"call-718","questions":[{"header":"Provide context","id":"freeform-718","isOther":false,"isSecret":false,"options":null,"question":"What comment should I post back to the issue?"}],"threadId":"thread-718","turnId":"turn-718"}}'
             ;;
+          5)
+            printf '%s\\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
           *)
-            sleep 1
+            exit 0
             ;;
         esac
       done
@@ -467,17 +471,123 @@ defmodule SymphonyElixir.AppServerTest do
       issue = %Issue{
         id: "issue-tool-user-input-required",
         identifier: "MT-718",
-        title: "Non approval tool input remains blocked",
-        description: "Ensure arbitrary tool prompts are not auto answered",
+        title: "Non interactive tool input answer",
+        description: "Ensure arbitrary tool prompts receive a generic answer",
         state: "In Progress",
         url: "https://example.org/issues/MT-718",
         labels: ["backend"]
       }
 
-      assert {:error, {:turn_input_required, payload}} =
-               AppServer.run(workspace, "Handle generic tool input", issue)
+      on_message = fn message -> send(self(), {:app_server_message, message}) end
 
-      assert payload["method"] == "item/tool/requestUserInput"
+      assert {:ok, _result} =
+               AppServer.run(workspace, "Handle generic tool input", issue, on_message: on_message)
+
+      assert_received {:app_server_message,
+                       %{
+                         event: :tool_input_auto_answered,
+                         answer: "This is a non-interactive session. Operator input is unavailable."
+                       }}
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server sends a generic non-interactive answer for option-based tool input prompts" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-tool-user-input-options-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-719")
+      codex_binary = Path.join(test_root, "fake-codex")
+      trace_file = Path.join(test_root, "codex-tool-user-input-options.trace")
+      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+
+      on_exit(fn ->
+        if is_binary(previous_trace) do
+          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+        else
+          System.delete_env("SYMP_TEST_CODEx_TRACE")
+        end
+      end)
+
+      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-options.trace}"
+      count=0
+      while IFS= read -r line; do
+        count=$((count + 1))
+        printf 'JSON:%s\\n' \"$line\" >> \"$trace_file\"
+
+        case \"$count\" in
+          1)
+            printf '%s\\n' '{\"id\":1,\"result\":{}}'
+            ;;
+          2)
+            ;;
+          3)
+            printf '%s\\n' '{\"id\":2,\"result\":{\"thread\":{\"id\":\"thread-719\"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{\"id\":3,\"result\":{\"turn\":{\"id\":\"turn-719\"}}}'
+            printf '%s\\n' '{\"id\":112,\"method\":\"item/tool/requestUserInput\",\"params\":{\"itemId\":\"call-719\",\"questions\":[{\"header\":\"Choose an action\",\"id\":\"options-719\",\"isOther\":false,\"isSecret\":false,\"options\":[{\"description\":\"Use the default behavior.\",\"label\":\"Use default\"},{\"description\":\"Skip this step.\",\"label\":\"Skip\"}],\"question\":\"How should I proceed?\"}],\"threadId\":\"thread-719\",\"turnId\":\"turn-719\"}}'
+            ;;
+          5)
+            printf '%s\\n' '{\"method\":\"turn/completed\"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-tool-user-input-options",
+        identifier: "MT-719",
+        title: "Option based tool input answer",
+        description: "Ensure option prompts receive a generic non-interactive answer",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-719",
+        labels: ["backend"]
+      }
+
+      assert {:ok, _result} =
+               AppServer.run(workspace, "Handle option based tool input", issue)
+
+      trace = File.read!(trace_file)
+      lines = String.split(trace, "\n", trim: true)
+
+      assert Enum.any?(lines, fn line ->
+               if String.starts_with?(line, "JSON:") do
+                 payload =
+                   line
+                   |> String.trim_leading("JSON:")
+                   |> Jason.decode!()
+
+                 payload["id"] == 112 and
+                   get_in(payload, ["result", "answers", "options-719", "answers"]) == [
+                     "This is a non-interactive session. Operator input is unavailable."
+                   ]
+               else
+                 false
+               end
+             end)
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -47,6 +47,24 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "/bin/sh app-server")
     assert :ok = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "definitely-not-valid")
+    assert :ok = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "unsafe-ish")
+    assert :ok = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_turn_sandbox_policy: %{type: "workspaceWrite", writableRoots: ["relative/path"]}
+    )
+
+    assert :ok = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: 123)
+    assert {:error, {:invalid_codex_approval_policy, 123}} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: 123)
+    assert {:error, {:invalid_codex_thread_sandbox, 123}} = Config.validate!()
   end
 
   test "current WORKFLOW.md file is valid and complete" do
@@ -1064,9 +1082,17 @@ defmodule SymphonyElixir.CoreTest do
                  |> String.trim_leading("JSON:")
                  |> Jason.decode!()
                  |> then(fn payload ->
+                   expected_approval_policy = %{
+                     "reject" => %{
+                       "sandbox_approval" => true,
+                       "rules" => true,
+                       "mcp_elicitations" => true
+                     }
+                   }
+
                    payload["method"] == "thread/start" &&
-                     get_in(payload, ["params", "approvalPolicy"]) == "never" &&
-                     get_in(payload, ["params", "sandbox"]) == "danger-full-access" &&
+                     get_in(payload, ["params", "approvalPolicy"]) == expected_approval_policy &&
+                     get_in(payload, ["params", "sandbox"]) == "workspace-write" &&
                      get_in(payload, ["params", "cwd"]) == Path.expand(workspace)
                  end)
                else
@@ -1074,16 +1100,33 @@ defmodule SymphonyElixir.CoreTest do
                end
              end)
 
+      expected_turn_sandbox_policy = %{
+        "type" => "workspaceWrite",
+        "writableRoots" => [Path.expand(workspace)],
+        "readOnlyAccess" => %{"type" => "fullAccess"},
+        "networkAccess" => false,
+        "excludeTmpdirEnvVar" => false,
+        "excludeSlashTmp" => false
+      }
+
       assert Enum.any?(lines, fn line ->
                if String.starts_with?(line, "JSON:") do
                  line
                  |> String.trim_leading("JSON:")
                  |> Jason.decode!()
                  |> then(fn payload ->
+                   expected_approval_policy = %{
+                     "reject" => %{
+                       "sandbox_approval" => true,
+                       "rules" => true,
+                       "mcp_elicitations" => true
+                     }
+                   }
+
                    payload["method"] == "turn/start" &&
                      get_in(payload, ["params", "cwd"]) == Path.expand(workspace) &&
-                     get_in(payload, ["params", "approvalPolicy"]) == "never" &&
-                     get_in(payload, ["params", "sandboxPolicy", "type"]) == "dangerFullAccess"
+                     get_in(payload, ["params", "approvalPolicy"]) == expected_approval_policy &&
+                     get_in(payload, ["params", "sandboxPolicy"]) == expected_turn_sandbox_policy
                  end)
                else
                  false
@@ -1174,6 +1217,127 @@ defmodule SymphonyElixir.CoreTest do
       assert String.contains?(argv_line, "--model gpt-5.3-codex app-server")
       refute String.contains?(argv_line, "--ask-for-approval never")
       refute String.contains?(argv_line, "--sandbox danger-full-access")
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
+  test "app server startup payload uses configurable approval and sandbox settings from workflow config" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-policy-overrides-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-99")
+      codex_binary = Path.join(test_root, "fake-codex")
+      trace_file = Path.join(test_root, "codex-policy-overrides.trace")
+      previous_trace = System.get_env("SYMP_TEST_CODex_TRACE")
+
+      on_exit(fn ->
+        if is_binary(previous_trace) do
+          System.put_env("SYMP_TEST_CODex_TRACE", previous_trace)
+        else
+          System.delete_env("SYMP_TEST_CODex_TRACE")
+        end
+      end)
+
+      System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-policy-overrides.trace}"
+      count=0
+
+      while IFS= read -r line; do
+        count=$((count + 1))
+        printf 'JSON:%s\\n' "$line" >> "$trace_file"
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-99"}}}'
+            ;;
+          3)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-99"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server",
+        codex_approval_policy: "on-request",
+        codex_thread_sandbox: "workspace-write",
+        codex_turn_sandbox_policy: %{
+          type: "workspaceWrite",
+          writableRoots: [Path.expand(workspace), Path.join(Path.expand(workspace_root), ".cache")]
+        }
+      )
+
+      issue = %Issue{
+        id: "issue-policy-overrides",
+        identifier: "MT-99",
+        title: "Validate codex policy overrides",
+        description: "Check startup policy payload overrides",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-99",
+        labels: ["backend"]
+      }
+
+      assert {:ok, _result} = AppServer.run(workspace, "Fix workspace start args", issue)
+
+      lines = File.read!(trace_file) |> String.split("\n", trim: true)
+
+      assert Enum.any?(lines, fn line ->
+               if String.starts_with?(line, "JSON:") do
+                 line
+                 |> String.trim_leading("JSON:")
+                 |> Jason.decode!()
+                 |> then(fn payload ->
+                   payload["method"] == "thread/start" &&
+                     get_in(payload, ["params", "approvalPolicy"]) == "on-request" &&
+                     get_in(payload, ["params", "sandbox"]) == "workspace-write"
+                 end)
+               else
+                 false
+               end
+             end)
+
+      expected_turn_policy = %{
+        "type" => "workspaceWrite",
+        "writableRoots" => [Path.expand(workspace), Path.join(Path.expand(workspace_root), ".cache")]
+      }
+
+      assert Enum.any?(lines, fn line ->
+               if String.starts_with?(line, "JSON:") do
+                 line
+                 |> String.trim_leading("JSON:")
+                 |> Jason.decode!()
+                 |> then(fn payload ->
+                   payload["method"] == "turn/start" &&
+                     get_in(payload, ["params", "approvalPolicy"]) == "on-request" &&
+                     get_in(payload, ["params", "sandboxPolicy"]) == expected_turn_policy
+                 end)
+               else
+                 false
+               end
+             end)
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1381,6 +1381,23 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert humanized =~ "auto-approved"
   end
 
+  test "status dashboard formats auto-answered tool input updates from codex" do
+    message = %{
+      event: :tool_input_auto_answered,
+      message: %{
+        payload: %{
+          "method" => "item/tool/requestUserInput",
+          "params" => %{"question" => "Continue?"}
+        },
+        answer: "This is a non-interactive session. Operator input is unavailable."
+      }
+    }
+
+    humanized = StatusDashboard.humanize_codex_message(message)
+    assert humanized =~ "tool requires user input"
+    assert humanized =~ "auto-answered"
+  end
+
   test "status dashboard enriches wrapper reasoning and message streaming events with payload context" do
     reasoning_message = %{
       event: :notification,

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -560,6 +560,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Config.workspace_root() == Path.join(System.tmp_dir!(), "symphony_workspaces")
     assert Config.max_concurrent_agents() == 10
     assert Config.codex_command() == "codex app-server"
+
     assert Config.codex_approval_policy() == %{
              "reject" => %{
                "sandbox_approval" => true,
@@ -567,6 +568,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
                "mcp_elicitations" => true
              }
            }
+
     assert Config.codex_thread_sandbox() == "workspace-write"
 
     assert Config.codex_turn_sandbox_policy() == %{
@@ -615,6 +617,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Config.codex_stall_timeout_ms() == 300_000
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "")
+
     assert Config.codex_approval_policy() == %{
              "reject" => %{
                "sandbox_approval" => true,
@@ -622,6 +625,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
                "mcp_elicitations" => true
              }
            }
+
     assert {:error, {:invalid_codex_approval_policy, ""}} = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "")

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -544,6 +544,9 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     write_workflow_file!(Workflow.workflow_file_path(),
       workspace_root: nil,
       max_concurrent_agents: nil,
+      codex_approval_policy: nil,
+      codex_thread_sandbox: nil,
+      codex_turn_sandbox_policy: nil,
       codex_turn_timeout_ms: nil,
       codex_read_timeout_ms: nil,
       codex_stall_timeout_ms: nil,
@@ -557,6 +560,23 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Config.workspace_root() == Path.join(System.tmp_dir!(), "symphony_workspaces")
     assert Config.max_concurrent_agents() == 10
     assert Config.codex_command() == "codex app-server"
+    assert Config.codex_approval_policy() == %{
+             "reject" => %{
+               "sandbox_approval" => true,
+               "rules" => true,
+               "mcp_elicitations" => true
+             }
+           }
+    assert Config.codex_thread_sandbox() == "workspace-write"
+
+    assert Config.codex_turn_sandbox_policy() == %{
+             "type" => "workspaceWrite",
+             "writableRoots" => [Path.expand(Path.join(System.tmp_dir!(), "symphony_workspaces"))],
+             "readOnlyAccess" => %{"type" => "fullAccess"},
+             "networkAccess" => false,
+             "excludeTmpdirEnvVar" => false,
+             "excludeSlashTmp" => false
+           }
 
     assert Config.codex_turn_timeout_ms() == 3_600_000
     assert Config.codex_read_timeout_ms() == 5_000
@@ -564,6 +584,20 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "codex app-server --model gpt-5.3-codex")
     assert Config.codex_command() == "codex app-server --model gpt-5.3-codex"
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_approval_policy: "on-request",
+      codex_thread_sandbox: "workspace-write",
+      codex_turn_sandbox_policy: %{type: "workspaceWrite", writableRoots: ["/tmp/workspace", "/tmp/cache"]}
+    )
+
+    assert Config.codex_approval_policy() == "on-request"
+    assert Config.codex_thread_sandbox() == "workspace-write"
+
+    assert Config.codex_turn_sandbox_policy() == %{
+             "type" => "workspaceWrite",
+             "writableRoots" => ["/tmp/workspace", "/tmp/cache"]
+           }
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: ",")
     assert Config.linear_active_states() == ["Todo", "In Progress"]
@@ -579,6 +613,53 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_stall_timeout_ms: "bad")
     assert Config.codex_stall_timeout_ms() == 300_000
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "")
+    assert Config.codex_approval_policy() == %{
+             "reject" => %{
+               "sandbox_approval" => true,
+               "rules" => true,
+               "mcp_elicitations" => true
+             }
+           }
+    assert {:error, {:invalid_codex_approval_policy, ""}} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "")
+    assert Config.codex_thread_sandbox() == "workspace-write"
+    assert {:error, {:invalid_codex_thread_sandbox, ""}} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(), codex_turn_sandbox_policy: "bad")
+
+    assert Config.codex_turn_sandbox_policy() == %{
+             "type" => "workspaceWrite",
+             "writableRoots" => [Path.expand(Path.join(System.tmp_dir!(), "symphony_workspaces"))],
+             "readOnlyAccess" => %{"type" => "fullAccess"},
+             "networkAccess" => false,
+             "excludeTmpdirEnvVar" => false,
+             "excludeSlashTmp" => false
+           }
+
+    assert {:error, {:invalid_codex_turn_sandbox_policy, {:unsupported_value, "bad"}}} =
+             Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      codex_approval_policy: "future-policy",
+      codex_thread_sandbox: "future-sandbox",
+      codex_turn_sandbox_policy: %{
+        type: "futureSandbox",
+        nested: %{flag: true}
+      }
+    )
+
+    assert Config.codex_approval_policy() == "future-policy"
+    assert Config.codex_thread_sandbox() == "future-sandbox"
+
+    assert Config.codex_turn_sandbox_policy() == %{
+             "type" => "futureSandbox",
+             "nested" => %{"flag" => true}
+           }
+
+    assert :ok = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "codex app-server")
     assert Config.codex_command() == "codex app-server"


### PR DESCRIPTION
#### Context

Symphony needs Codex runtime policy settings to be implementation-controlled, and unattended runs were still retry-looping on MCP tool prompts instead of letting Codex continue the turn.

#### TL;DR

*Make Codex runtime policies configurable and keep non-interactive runs moving through tool prompts.*

#### Summary

- Add `codex.approval_policy`, `codex.thread_sandbox`, and `codex.turn_sandbox_policy` to the Elixir workflow config.
- Use implementation-defined defaults and treat Codex-owned policy values as pass-through config instead of spec enums.
- Update the app-server client to honor configured policies and surface safer non-`never` approval behavior.
- Auto-handle MCP approval-style `requestUserInput` prompts under `approval_policy: never` for unattended runs.
- Reply to other tool input prompts with a generic non-interactive answer so Codex can recover in the same turn.
- Restore explicit full-access local sandbox settings in `elixir/WORKFLOW.md` for trusted local runs.
- Update docs and tests to cover the new config surface and runtime behavior.

#### Alternatives

- Keep hard-coded Codex policy enums and nested validation in Symphony. Rejected because it will drift from Codex app-server.
- Keep aborting on tool input prompts. Rejected because Symphony just retries and re-hits the same prompt.
- Deep-validate Codex-owned config locally. Rejected for now because the schema source of truth already lives in Codex.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/app_server_test.exs test/symphony_elixir/core_test.exs test/symphony_elixir/workspace_and_config_test.exs`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/app_server_test.exs test/symphony_elixir/orchestrator_status_test.exs`
