### PR TITLE
MT-718: Keep status dashboard corner border from dimming

### DIFF
--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -128,7 +128,7 @@ defmodule SymphonyElixir.StatusDashboard do
       [
         colorize("╭─ SYMPHONY STATUS", @ansi_bold),
         colorize("│ app_status=offline", @ansi_red),
-        colorize("╰─", @ansi_gray)
+        closing_border()
       ]
       |> Enum.join("\n")
 
@@ -366,7 +366,7 @@ defmodule SymphonyElixir.StatusDashboard do
            running_rows ++
            [colorize("├─ Backoff queue", @ansi_bold), "│"] ++
            backoff_rows ++
-           [colorize("╰─", @ansi_gray)])
+           [closing_border()])
         |> List.flatten()
         |> Enum.join("\n")
 
@@ -377,7 +377,7 @@ defmodule SymphonyElixir.StatusDashboard do
           colorize("│ Throughput: ", @ansi_bold) <> colorize("#{format_tps(tps)} tps", @ansi_cyan),
           format_project_link_lines(),
           format_project_refresh_line(nil),
-          colorize("╰─", @ansi_gray)
+          closing_border()
         ]
         |> List.flatten()
         |> Enum.join("\n")
@@ -1044,6 +1044,8 @@ defmodule SymphonyElixir.StatusDashboard do
   defp normalize_status_lines(content) do
     content
   end
+
+  defp closing_border, do: "╰─"
 
   defp colorize(value, code) do
     "#{code}#{value}#{@ansi_reset}"

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
@@ -16,4 +16,4 @@
 │  \e[33m↻\e[0m \e[31mMT-450\e[0m \e[33mattempt=4\e[0m\e[2m in \e[0m\e[36m1.250s\e[0m \e[2merror=rate limit exhausted\e[0m
 │  \e[33m↻\e[0m \e[31mMT-451\e[0m \e[33mattempt=2\e[0m\e[2m in \e[0m\e[36m3.900s\e[0m \e[2merror=retrying after API timeout with jitter\e[0m
 │  \e[33m↻\e[0m \e[31mMT-452\e[0m \e[33mattempt=6\e[0m\e[2m in \e[0m\e[36m8.100s\e[0m \e[2merror=worker crashed restarting cleanly\e[0m
-\e[90m╰─\e[0m
+╰─

--- a/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/credits_unlimited.snapshot.txt
@@ -14,4 +14,4 @@
 \e[1m├─ Backoff queue\e[0m
 │
 │  \e[90mNo queued retries\e[0m
-\e[90m╰─\e[0m
+╰─

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle.snapshot.txt
@@ -15,4 +15,4 @@
 \e[1m├─ Backoff queue\e[0m
 │
 │  \e[90mNo queued retries\e[0m
-\e[90m╰─\e[0m
+╰─

--- a/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/idle_with_dashboard_url.snapshot.txt
@@ -16,4 +16,4 @@
 \e[1m├─ Backoff queue\e[0m
 │
 │  \e[90mNo queued retries\e[0m
-\e[90m╰─\e[0m
+╰─

--- a/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/super_busy.snapshot.txt
@@ -15,4 +15,4 @@
 \e[1m├─ Backoff queue\e[0m
 │
 │  \e[90mNo queued retries\e[0m
-\e[90m╰─\e[0m
+╰─

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1065,6 +1065,21 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert plain =~ ~r/No active agents\r?\n│\s*\r?\n├─ Backoff queue/
   end
 
+  test "status dashboard renders an unstyled closing corner when the retry queue is empty" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [],
+         retrying: [],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    rendered = StatusDashboard.format_snapshot_content_for_test(snapshot_data, 0.0)
+
+    assert rendered |> String.split("\n") |> List.last() == "╰─"
+  end
+
   test "status dashboard coalesces rapid updates to one render per interval" do
     dashboard_name = Module.concat(__MODULE__, :RenderDashboard)
     parent = self()


### PR DESCRIPTION
#### Context

The empty backoff queue line dims `No queued retries`, but the same ANSI scope also dims the closing `╰─`, which makes the left border look inconsistent.

#### TL;DR

*Keep the status dashboard closing corner unstyled so dim retry text does not dim the border.*

#### Summary

- Route dashboard footer rendering through a shared unstyled `closing_border/0` helper
- Apply the helper to online, offline, and snapshot-unavailable render paths
- Update snapshot fixtures and add a regression test for the empty retry queue footer

#### Alternatives

- Keep the footer gray and restyle each content line separately; this keeps border styling coupled to nearby content
- Recolor the footer with another ANSI code; this still depends on formatting scopes instead of structural rendering

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mix test test/symphony_elixir/status_dashboard_snapshot_test.exs test/symphony_elixir/orchestrator_status_test.exs`
- [x] `cd elixir && mix test test/symphony_elixir/orchestrator_status_test.exs:1068`
