### PR TITLE
Slow down initial issue-agent failure backoff

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -598,8 +598,9 @@ Important nuance:
 - The first turn should use the full rendered task prompt.
 - Continuation turns should send only continuation guidance to the existing thread, not resend the
   original task prompt that is already present in thread history.
-- Once the worker exits normally, the orchestrator still schedules a short continuation retry so it
-  can re-check whether the issue remains active and needs another worker session.
+- Once the worker exits normally, the orchestrator still schedules a short continuation retry
+  (about 1 second) so it can re-check whether the issue remains active and needs another worker
+  session.
 
 ### 7.2 Run Attempt Lifecycle
 
@@ -720,8 +721,9 @@ Retry entry creation:
 
 Backoff formula:
 
-- `delay = min(1000 * 2^(attempt - 1), agent.max_retry_backoff_ms)`
-- Power is capped by the configured max retry backoff (default `300000` / 5m)
+- Normal continuation retries after a clean worker exit use a short fixed delay of `1000` ms.
+- Failure-driven retries use `delay = min(10000 * 2^(attempt - 1), agent.max_retry_backoff_ms)`.
+- Power is capped by the configured max retry backoff (default `300000` / 5m).
 
 Retry handling behavior:
 
@@ -1826,7 +1828,10 @@ on_worker_exit(issue_id, reason, state):
 
   if reason == normal:
     state.completed.add(issue_id)  # bookkeeping only
-    state = schedule_retry(state, issue_id, 1, {identifier: running_entry.identifier})
+    state = schedule_retry(state, issue_id, 1, {
+      identifier: running_entry.identifier,
+      delay_type: continuation
+    })
   else:
     state = schedule_retry(state, issue_id, next_attempt_from(running_entry), {
       identifier: running_entry.identifier,
@@ -1938,8 +1943,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Non-active state stops running agent without workspace cleanup
 - Terminal state stops running agent and cleans workspace
 - Reconciliation with no running issues is a no-op
-- Normal worker exit schedules continuation retry (attempt 1)
-- Abnormal worker exit increments retries with backoff
+- Normal worker exit schedules a short continuation retry (attempt 1)
+- Abnormal worker exit increments retries with 10s-based exponential backoff
 - Retry backoff cap uses configured `agent.max_retry_backoff_ms`
 - Retry queue entries include attempt, due time, identifier, and error
 - Stall detection kills stalled sessions and schedules retry

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -10,7 +10,8 @@ defmodule SymphonyElixir.Orchestrator do
   alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
   alias SymphonyElixir.Linear.Issue
 
-  @retry_base_ms 1_000
+  @continuation_retry_delay_ms 1_000
+  @failure_retry_base_ms 10_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
   @empty_codex_totals %{
@@ -107,7 +108,10 @@ defmodule SymphonyElixir.Orchestrator do
 
               state
               |> complete_issue(issue_id)
-              |> schedule_issue_retry(issue_id, 1, %{identifier: running_entry.identifier})
+              |> schedule_issue_retry(issue_id, 1, %{
+                identifier: running_entry.identifier,
+                delay_type: :continuation
+              })
 
             _ ->
               Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
@@ -597,7 +601,7 @@ defmodule SymphonyElixir.Orchestrator do
        when is_binary(issue_id) and is_map(metadata) do
     previous_retry = Map.get(state.retry_attempts, issue_id, %{attempt: 0})
     next_attempt = if is_integer(attempt), do: attempt, else: previous_retry.attempt + 1
-    delay_ms = retry_delay(next_attempt)
+    delay_ms = retry_delay(next_attempt, metadata)
     old_timer = Map.get(previous_retry, :timer_ref)
     due_at_ms = System.monotonic_time(:millisecond) + delay_ms
     identifier = pick_retry_identifier(issue_id, previous_retry, metadata)
@@ -737,9 +741,17 @@ defmodule SymphonyElixir.Orchestrator do
     %{state | claimed: MapSet.delete(state.claimed, issue_id)}
   end
 
-  defp retry_delay(attempt) do
+  defp retry_delay(attempt, metadata) when is_integer(attempt) and attempt > 0 and is_map(metadata) do
+    if metadata[:delay_type] == :continuation and attempt == 1 do
+      @continuation_retry_delay_ms
+    else
+      failure_retry_delay(attempt)
+    end
+  end
+
+  defp failure_retry_delay(attempt) do
     max_delay_power = min(attempt - 1, 10)
-    min(@retry_base_ms * (1 <<< max_delay_power), Config.max_retry_backoff_ms())
+    min(@failure_retry_base_ms * (1 <<< max_delay_power), Config.max_retry_backoff_ms())
   end
 
   defp normalize_retry_attempt(attempt) when is_integer(attempt) and attempt > 0, do: attempt

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -371,6 +371,7 @@ defmodule SymphonyElixir.CoreTest do
     assert MapSet.member?(state.completed, issue_id)
     assert %{attempt: 1, due_at_ms: due_at_ms} = state.retry_attempts[issue_id]
     assert is_integer(due_at_ms)
+    assert_due_in_range(due_at_ms, 500, 1_100)
   end
 
   test "abnormal worker exit increments retry attempt progressively" do
@@ -407,7 +408,56 @@ defmodule SymphonyElixir.CoreTest do
     Process.sleep(50)
     state = :sys.get_state(pid)
 
-    assert %{attempt: 3, identifier: "MT-559", error: "agent exited: :boom"} = state.retry_attempts[issue_id]
+    assert %{attempt: 3, due_at_ms: due_at_ms, identifier: "MT-559", error: "agent exited: :boom"} =
+             state.retry_attempts[issue_id]
+
+    assert_due_in_range(due_at_ms, 39_500, 40_500)
+  end
+
+  test "first abnormal worker exit waits before retrying" do
+    issue_id = "issue-crash-initial"
+    ref = make_ref()
+    orchestrator_name = Module.concat(__MODULE__, :InitialCrashRetryOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: ref,
+      identifier: "MT-560",
+      issue: %Issue{id: issue_id, identifier: "MT-560", state: "In Progress"},
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.new([issue_id]))
+      |> Map.put(:retry_attempts, %{})
+    end)
+
+    send(pid, {:DOWN, ref, :process, self(), :boom})
+    Process.sleep(50)
+    state = :sys.get_state(pid)
+
+    assert %{attempt: 1, due_at_ms: due_at_ms, identifier: "MT-560", error: "agent exited: :boom"} =
+             state.retry_attempts[issue_id]
+
+    assert_due_in_range(due_at_ms, 9_500, 10_500)
+  end
+
+  defp assert_due_in_range(due_at_ms, min_remaining_ms, max_remaining_ms) do
+    remaining_ms = due_at_ms - System.monotonic_time(:millisecond)
+
+    assert remaining_ms >= min_remaining_ms
+    assert remaining_ms <= max_remaining_ms
   end
 
   test "fetch issues by states with empty state set is a no-op" do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -954,6 +954,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            } = state.retry_attempts[issue_id]
 
     assert is_integer(due_at_ms)
+    remaining_ms = due_at_ms - System.monotonic_time(:millisecond)
+    assert remaining_ms >= 9_500
+    assert remaining_ms <= 10_500
   end
 
   test "status dashboard renders offline marker to terminal" do


### PR DESCRIPTION
#### Context

Issue agents were retrying about one second after a failed run. MT-719
needs the first failure retry to wait at least 10 seconds while keeping
normal continuation retries fast.

#### TL;DR

Increase the first failure retry delay to 10s without slowing normal continuation retries.

#### Summary

- split orchestrator retry scheduling into 1s continuation retries and 10s-based failure retries
- add focused retry timing coverage for continuation, first failure, and later backoff steps
- update `SPEC.md` so the documented retry policy matches the implementation

#### Alternatives

- increase all retries to 10s, but that would slow normal post-completion rechecks
- add a separate config knob, but the retry split is fixed product behavior for now

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix test test/symphony_elixir/core_test.exs:337 test/symphony_elixir/core_test.exs:377 test/symphony_elixir/core_test.exs:417 test/symphony_elixir/orchestrator_status_test.exs:898`
- [x] `mix run -e '<retry timing harness>'`
- [x] `git diff --check`
