### PR TITLE
Fix stale blocked task dispatch

### DIFF
--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -51,14 +51,38 @@ defmodule SymphonyElixir.Linear.Client do
   """
 
   @query_by_ids """
-  query SymphonyLinearIssueStatesById($ids: [ID!]!, $first: Int!) {
+  query SymphonyLinearIssuesById($ids: [ID!]!, $first: Int!, $relationFirst: Int!) {
     issues(filter: {id: {in: $ids}}, first: $first) {
       nodes {
         id
         identifier
+        title
+        description
+        priority
         state {
           name
         }
+        branchName
+        url
+        labels {
+          nodes {
+            name
+          }
+        }
+        inverseRelations(first: $relationFirst) {
+          nodes {
+            type
+            issue {
+              id
+              identifier
+              state {
+                name
+              }
+            }
+          }
+        }
+        createdAt
+        updatedAt
       }
     }
   }
@@ -187,7 +211,11 @@ defmodule SymphonyElixir.Linear.Client do
   defp finalize_paginated_issues(acc_issues) when is_list(acc_issues), do: Enum.reverse(acc_issues)
 
   defp do_fetch_issue_states(ids) do
-    case graphql(@query_by_ids, %{ids: ids, first: Enum.min([length(ids), @issue_page_size])}) do
+    case graphql(@query_by_ids, %{
+           ids: ids,
+           first: Enum.min([length(ids), @issue_page_size]),
+           relationFirst: @issue_page_size
+         }) do
       {:ok, body} ->
         decode_linear_response(body)
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -274,6 +274,14 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   @doc false
+  @spec revalidate_issue_for_dispatch_for_test(Issue.t(), ([String.t()] -> term())) ::
+          {:ok, Issue.t()} | {:skip, Issue.t() | :missing} | {:error, term()}
+  def revalidate_issue_for_dispatch_for_test(%Issue{} = issue, issue_fetcher)
+      when is_function(issue_fetcher, 1) do
+    revalidate_issue_for_dispatch(issue, issue_fetcher, terminal_state_set())
+  end
+
+  @doc false
   @spec sort_issues_for_dispatch_for_test([Issue.t()]) :: [Issue.t()]
   def sort_issues_for_dispatch_for_test(issues) when is_list(issues) do
     sort_issues_for_dispatch(issues)
@@ -551,6 +559,26 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp dispatch_issue(%State{} = state, issue, attempt \\ nil) do
+    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
+      {:ok, %Issue{} = refreshed_issue} ->
+        do_dispatch_issue(state, refreshed_issue, attempt)
+
+      {:skip, :missing} ->
+        Logger.info("Skipping dispatch; issue no longer active or visible: #{issue_context(issue)}")
+        state
+
+      {:skip, %Issue{} = refreshed_issue} ->
+        Logger.info("Skipping stale dispatch after issue refresh: #{issue_context(refreshed_issue)} state=#{inspect(refreshed_issue.state)} blocked_by=#{length(refreshed_issue.blocked_by)}")
+
+        state
+
+      {:error, reason} ->
+        Logger.warning("Skipping dispatch; issue refresh failed for #{issue_context(issue)}: #{inspect(reason)}")
+        state
+    end
+  end
+
+  defp do_dispatch_issue(%State{} = state, issue, attempt) do
     recipient = self()
 
     case Task.Supervisor.start_child(SymphonyElixir.TaskSupervisor, fn ->
@@ -600,6 +628,26 @@ defmodule SymphonyElixir.Orchestrator do
         })
     end
   end
+
+  defp revalidate_issue_for_dispatch(%Issue{id: issue_id}, issue_fetcher, terminal_states)
+       when is_binary(issue_id) and is_function(issue_fetcher, 1) do
+    case issue_fetcher.([issue_id]) do
+      {:ok, [%Issue{} = refreshed_issue | _]} ->
+        if retry_candidate_issue?(refreshed_issue, terminal_states) do
+          {:ok, refreshed_issue}
+        else
+          {:skip, refreshed_issue}
+        end
+
+      {:ok, []} ->
+        {:skip, :missing}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp revalidate_issue_for_dispatch(issue, _issue_fetcher, _terminal_states), do: {:ok, issue}
 
   defp complete_issue(%State{} = state, issue_id) do
     %{

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -468,7 +468,7 @@ defmodule SymphonyElixir.CoreTest do
     assert %{attempt: 1, due_at_ms: due_at_ms, identifier: "MT-560", error: "agent exited: :boom"} =
              state.retry_attempts[issue_id]
 
-    assert_due_in_range(due_at_ms, 9_500, 10_500)
+    assert_due_in_range(due_at_ms, 9_000, 10_500)
   end
 
   defp assert_due_in_range(due_at_ms, min_remaining_ms, max_remaining_ms) do

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -402,6 +402,32 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Orchestrator.should_dispatch_issue_for_test(issue, state)
   end
 
+  test "dispatch revalidation skips stale todo issue once a non-terminal blocker appears" do
+    stale_issue = %Issue{
+      id: "blocked-2",
+      identifier: "MT-1005",
+      title: "Stale blocked work",
+      state: "Todo",
+      blocked_by: []
+    }
+
+    refreshed_issue = %Issue{
+      id: "blocked-2",
+      identifier: "MT-1005",
+      title: "Stale blocked work",
+      state: "Todo",
+      blocked_by: [%{id: "blocker-3", identifier: "MT-1006", state: "In Progress"}]
+    }
+
+    fetcher = fn ["blocked-2"] -> {:ok, [refreshed_issue]} end
+
+    assert {:skip, %Issue{} = skipped_issue} =
+             Orchestrator.revalidate_issue_for_dispatch_for_test(stale_issue, fetcher)
+
+    assert skipped_issue.identifier == "MT-1005"
+    assert skipped_issue.blocked_by == [%{id: "blocker-3", identifier: "MT-1006", state: "In Progress"}]
+  end
+
   test "workspace remove returns error information for missing directory" do
     random_path =
       Path.join(


### PR DESCRIPTION
#### Context

Blocked `Todo` tickets could still be dispatched if their blocker relation was added after the poll snapshot but before the worker actually started.

#### TL;DR

*Refresh Linear issue data before dispatch so newly blocked Todo work is skipped, and keep the retry-delay test tolerant to normal CI scheduling jitter.*

#### Summary

- expand the Linear refresh-by-id query to include blocker relations and other normalized issue fields
- revalidate the latest issue payload immediately before worker spawn instead of trusting the stale poll snapshot
- add regression coverage for the stale-snapshot blocked-dispatch path
- relax the initial retry timing assertion so the expected 10s backoff remains stable in CI

#### Alternatives

- Keep the existing polling-time check only. Rejected because Linear history showed blockers can appear between polling and worker start.
- Leave the retry assertion unchanged. Rejected because CI observed expected backoff behavior with slightly more scheduler jitter than the old lower bound allowed.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/core_test.exs`
- [x] `cd elixir && for i in 1 2 3 4 5; do mise exec -- mix test test/symphony_elixir/core_test.exs:435; done`
