### PR TITLE
Show full backoff queue

### DIFF
--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -645,7 +645,6 @@ defmodule SymphonyElixir.StatusDashboard do
     else
       retrying
       |> Enum.sort_by(& &1.due_in_ms)
-      |> Enum.take(3)
       |> Enum.map_join(", ", &format_retry_summary/1)
       |> String.split(", ")
     end

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.evidence.md
@@ -18,5 +18,6 @@
 │  ↻ MT-450 attempt=4 in 1.250s error=rate limit exhausted
 │  ↻ MT-451 attempt=2 in 3.900s error=retrying after API timeout with jitter
 │  ↻ MT-452 attempt=6 in 8.100s error=worker crashed restarting cleanly
+│  ↻ MT-453 attempt=1 in 11.000s error=fourth queued retry should also render after removing the top-three limit
 ╰─
 ```

--- a/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
+++ b/elixir/test/fixtures/status_dashboard_snapshots/backoff_queue.snapshot.txt
@@ -17,4 +17,5 @@
 │  \e[33m↻\e[0m \e[31mMT-450\e[0m \e[33mattempt=4\e[0m\e[2m in \e[0m\e[36m1.250s\e[0m \e[2merror=rate limit exhausted\e[0m
 │  \e[33m↻\e[0m \e[31mMT-451\e[0m \e[33mattempt=2\e[0m\e[2m in \e[0m\e[36m3.900s\e[0m \e[2merror=retrying after API timeout with jitter\e[0m
 │  \e[33m↻\e[0m \e[31mMT-452\e[0m \e[33mattempt=6\e[0m\e[2m in \e[0m\e[36m8.100s\e[0m \e[2merror=worker crashed restarting cleanly\e[0m
+│  \e[33m↻\e[0m \e[31mMT-453\e[0m \e[33mattempt=1\e[0m\e[2m in \e[0m\e[36m11.000s\e[0m \e[2merror=fourth queued retry should also render after removing the top-three limit\e[0m
 ╰─

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -123,7 +123,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
              identifier: "MT-453",
              attempt: 1,
              due_in_ms: 11_000,
-             error: "this row should be trimmed because only the top three retries render"
+             error: "fourth queued retry should also render after removing the top-three limit"
            })
          ],
          codex_totals: %{input_tokens: 18_000, output_tokens: 2_200, total_tokens: 20_200, seconds_running: 2_700},


### PR DESCRIPTION
#### Context

MT-861 reports that the dashboard was only showing the first three items in the backoff queue, making it hard to see all queued retries.

#### TL;DR

Show the full backoff queue so every retry entry is visible in the dashboard.

#### Summary

- Removed the fixed top-3 cap from retry row formatting in the status dashboard.
- Updated backoff queue snapshot fixtures to include all retry entries.
- Added validation coverage via existing snapshot test run.

#### Alternatives

- Kept the hard cap and would have required a separate "view more" mechanism, which is not part of current UI.

#### Test Plan

- [x] make -C elixir all
- [x] cd elixir && mix test test/symphony_elixir/status_dashboard_snapshot_test.exs
