### PR TITLE
Handle escaped newlines in backoff queue

### DIFF
--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -675,7 +675,13 @@ defmodule SymphonyElixir.StatusDashboard do
   defp next_in_words(_), do: "n/a"
 
   defp format_retry_error(error) when is_binary(error) do
-    sanitized = error |> String.replace(~r/\s+/, " ") |> String.trim()
+    sanitized =
+      error
+      |> String.replace("\\\\n", " ")
+      |> String.replace("\\\\r", " ")
+      |> String.replace("\\\\t", " ")
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
 
     if sanitized == "" do
       ""

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -677,9 +677,7 @@ defmodule SymphonyElixir.StatusDashboard do
   defp format_retry_error(error) when is_binary(error) do
     sanitized =
       error
-      |> String.replace("\\\\n", " ")
-      |> String.replace("\\\\r", " ")
-      |> String.replace("\\\\t", " ")
+      |> String.replace(~r/\\+[nrt]/, " ")
       |> String.replace(~r/\s+/, " ")
       |> String.trim()
 

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -138,6 +138,37 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     Snapshot.assert_dashboard_snapshot!("backoff_queue", render_snapshot(snapshot_data, 15.4))
   end
 
+  test "backoff queue normalizes escaped and literal newlines in retry errors" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [],
+         retrying: [
+           retry_entry(%{
+             identifier: "MT-867-1",
+             attempt: 1,
+             due_in_ms: 500,
+             error: "escaped\\\\nerror"
+           }),
+           retry_entry(%{
+             identifier: "MT-867-2",
+             attempt: 2,
+             due_in_ms: 1_000,
+             error: "literal\nerror"
+           })
+         ],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    output = render_snapshot(snapshot_data, 0.0)
+
+    assert output =~ "MT-867-1"
+    assert output =~ "error=escaped error"
+    assert output =~ "MT-867-2"
+    assert output =~ "error=literal error"
+  end
+
   test "snapshot fixture: unlimited credits variant" do
     snapshot_data =
       {:ok,

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -155,6 +155,12 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
              attempt: 2,
              due_in_ms: 1_000,
              error: "literal\nerror"
+           }),
+           retry_entry(%{
+             identifier: "MT-867-3",
+             attempt: 3,
+             due_in_ms: 1_500,
+             error: ~S"double\\\\nerror"
            })
          ],
          codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
@@ -167,6 +173,8 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     assert output =~ "error=escaped error"
     assert output =~ "MT-867-2"
     assert output =~ "error=literal error"
+    assert output =~ "MT-867-3"
+    assert output =~ "error=double error"
   end
 
   test "snapshot fixture: unlimited credits variant" do


### PR DESCRIPTION
#### Context
Backoff queue messages can include literal and escaped newline escapes that break the dashboard line layout.

#### TL;DR
Normalize backoff retry errors so they render on one line in the dashboard.

#### Summary

- Sanitize backoff queue errors by replacing `\\n`, `\\r`, and `\\t` escape sequences with spaces before whitespace collapsing.
- Keep literal newline and whitespace handling through the existing normalization flow.
- Add snapshot coverage for escaped/newline error strings in backoff queue output.

#### Alternatives

- Leave rendering unchanged, which would keep malformed queue rows visible to users.

#### Test Plan

- [ ] `cd elixir && make -C elixir all`
- [ ] `cd elixir && mix test test/symphony_elixir/status_dashboard_snapshot_test.exs`
