### PR TITLE
Handle \n in backoff queue

### DIFF
--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -675,7 +675,11 @@ defmodule SymphonyElixir.StatusDashboard do
   defp next_in_words(_), do: "n/a"
 
   defp format_retry_error(error) when is_binary(error) do
-    sanitized = error |> String.replace(~r/\s+/, " ") |> String.trim()
+    sanitized =
+      error
+      |> String.replace(~r/\\+[nrt]/, " ")
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
 
     if sanitized == "" do
       ""

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -138,6 +138,45 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     Snapshot.assert_dashboard_snapshot!("backoff_queue", render_snapshot(snapshot_data, 15.4))
   end
 
+  test "backoff queue normalizes escaped and literal newlines in retry errors" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [],
+         retrying: [
+           retry_entry(%{
+             identifier: "MT-867-1",
+             attempt: 1,
+             due_in_ms: 500,
+             error: "escaped\\\\nerror"
+           }),
+           retry_entry(%{
+             identifier: "MT-867-2",
+             attempt: 2,
+             due_in_ms: 1_000,
+             error: "literal\nerror"
+           }),
+           retry_entry(%{
+             identifier: "MT-867-3",
+             attempt: 3,
+             due_in_ms: 1_500,
+             error: ~S"double\\\\nerror"
+           })
+         ],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    output = render_snapshot(snapshot_data, 0.0)
+
+    assert output =~ "MT-867-1"
+    assert output =~ "error=escaped error"
+    assert output =~ "MT-867-2"
+    assert output =~ "error=literal error"
+    assert output =~ "MT-867-3"
+    assert output =~ "error=double error"
+  end
+
   test "snapshot fixture: unlimited credits variant" do
     snapshot_data =
       {:ok,


### PR DESCRIPTION
#### Context

Normalize escaped and literal newline sequences in backoff queue retry errors before rendering in the status dashboard so layout is not broken by multi-line messages.

#### TL;DR

Harden dashboard error formatting by flattening newlines in retry messages.

#### Summary

- Add newline/escape handling to `format_retry_error/1` in `status_dashboard`.
- Add regression coverage for escaped and literal newline variants in snapshot tests.
- Keep PR body formatted per repository template so `validate-pr-description` passes.

#### Alternatives

- Keeping escaped newline sequences would preserve existing formatting but still break layout on multiline payloads.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mix test test/symphony_elixir/status_dashboard_snapshot_test.exs`
