### PR TITLE
fix(status-dashboard): normalize backoff queue error newlines

### DIFF
--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -675,7 +675,16 @@ defmodule SymphonyElixir.StatusDashboard do
   defp next_in_words(_), do: "n/a"
 
   defp format_retry_error(error) when is_binary(error) do
-    sanitized = error |> String.replace(~r/\s+/, " ") |> String.trim()
+    sanitized =
+      error
+      |> String.replace("\\r\\n", " ")
+      |> String.replace("\\r", " ")
+      |> String.replace("\\n", " ")
+      |> String.replace("\r\n", " ")
+      |> String.replace("\r", " ")
+      |> String.replace("\n", " ")
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
 
     if sanitized == "" do
       ""

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -138,6 +138,34 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     Snapshot.assert_dashboard_snapshot!("backoff_queue", render_snapshot(snapshot_data, 15.4))
   end
 
+  test "backoff queue row escapes escaped newline sequences" do
+    snapshot_data =
+      {:ok,
+       %{
+         running: [],
+         retrying: [
+           retry_entry(%{
+             identifier: "MT-980",
+             attempt: 1,
+             due_in_ms: 1_500,
+             error: "error with \\nnewline"
+           })
+         ],
+         codex_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         rate_limits: nil
+       }}
+
+    rendered = render_snapshot(snapshot_data, 0.0)
+    backoff_lines = rendered |> String.split("\n") |> Enum.filter(&String.contains?(&1, "MT-980"))
+
+    assert length(backoff_lines) == 1
+
+    [backoff_line] = backoff_lines
+
+    assert backoff_line =~ "error=error with newline"
+    refute backoff_line =~ "\\n"
+  end
+
   test "snapshot fixture: unlimited credits variant" do
     snapshot_data =
       {:ok,


### PR DESCRIPTION
#### Context

Error messages in the status dashboard backoff queue may include escaped newlines (`\\n`), which can distort row rendering.

#### TL;DR

Normalize backoff queue error text so rows stay on one line and stay readable.

#### Summary

- Normalize both escaped and raw newline sequences in retry error formatting for dashboard backoff rows.
- Add dashboard snapshot coverage for escaped `\\n` handling in backoff queue messages.

#### Alternatives

- Rely on upstream sources to pre-sanitize error messages before storing retry metadata.

#### Test Plan

- [ ] make -C elixir all
- [x] cd elixir && mix test test/symphony_elixir/status_dashboard_snapshot_test.exs
