### PR TITLE
[JM-10] Add a standalone pomodoro web app

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1359,8 +1359,11 @@ If implemented:
 
 - The HTTP server is an extension and is not required for conformance.
 - The implementation may serve server-rendered HTML or a client-side application for the dashboard.
-- The dashboard/API must be observability/control surfaces only and must not become required for
-  orchestrator correctness.
+- The dashboard and `/api/v1/*` contract must remain observability/control surfaces only and must
+  not become required for orchestrator correctness.
+- Implementations may expose additional explicitly optional routes (for example a self-contained
+  local demo at `/pomodoro`) as long as those routes stay separate from the dashboard/API contract
+  and are never required for orchestration.
 
 Enablement (extension):
 
@@ -1383,6 +1386,8 @@ Enablement (extension):
   retry delays, token consumption, runtime totals, recent events, and health/error indicators).
 - It is up to the implementation whether this is server-generated HTML or a client-side app that
   consumes the JSON API below.
+- Additional implementation-specific HTML pages may exist at other routes, but they are optional
+  and outside the conformance surface defined in this section.
 
 #### 13.7.2 JSON REST API (`/api/v1/*`)
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -125,8 +125,9 @@ codex:
 ```
 
 - If `WORKFLOW.md` is missing or has invalid YAML, startup and scheduling are halted until fixed.
-- `server.port` or CLI `--port` enables the optional HTTP dashboard and JSON API at `/`,
-  `/api/v1/state`, `/api/v1/<issue_identifier>`, and `/api/v1/refresh`.
+- `server.port` or CLI `--port` enables the optional HTTP dashboard plus pomodoro demo at `/`
+  and `/pomodoro`, alongside the JSON API at `/api/v1/state`, `/api/v1/<issue_identifier>`,
+  and `/api/v1/refresh`.
 
 ## Project Layout
 

--- a/elixir/lib/symphony_elixir/http_server.ex
+++ b/elixir/lib/symphony_elixir/http_server.ex
@@ -231,6 +231,9 @@ defmodule SymphonyElixir.HttpServer do
   defp route(%{method: "GET", path: "/"} = request, orchestrator, snapshot_timeout_ms),
     do: html_response(200, render_dashboard(request, orchestrator, snapshot_timeout_ms))
 
+  defp route(%{method: "GET", path: "/pomodoro"}, _orchestrator, _snapshot_timeout_ms),
+    do: html_response(200, render_pomodoro_app())
+
   defp route(%{method: "GET", path: "/api/v1/state"}, orchestrator, snapshot_timeout_ms),
     do: json_response(200, state_payload(orchestrator, snapshot_timeout_ms))
 
@@ -258,6 +261,9 @@ defmodule SymphonyElixir.HttpServer do
   end
 
   defp route(%{path: "/"}, _orchestrator, _snapshot_timeout_ms),
+    do: error_response(405, "method_not_allowed", "Method not allowed")
+
+  defp route(%{path: "/pomodoro"}, _orchestrator, _snapshot_timeout_ms),
     do: error_response(405, "method_not_allowed", "Method not allowed")
 
   defp route(%{path: "/api/v1/" <> _issue_identifier}, _orchestrator, _snapshot_timeout_ms),
@@ -420,13 +426,642 @@ defmodule SymphonyElixir.HttpServer do
         <title>#{title}</title>
         <style>
           body { font-family: Menlo, Monaco, monospace; margin: 24px; background: #f4efe6; color: #1f1d1a; }
-          h1 { margin: 0 0 16px; }
+          h1 { margin: 0 0 12px; }
+          p { margin: 0 0 16px; line-height: 1.5; max-width: 60rem; }
+          .nav-links { display: flex; gap: 12px; margin: 0 0 20px; flex-wrap: wrap; }
+          .nav-links a { color: #2563eb; text-decoration: none; font-weight: 600; }
+          .nav-links a:hover { text-decoration: underline; }
           pre { padding: 16px; border-radius: 12px; background: #fffdf8; border: 1px solid #d8cfbf; overflow: auto; }
         </style>
       </head>
       <body>
         <h1>#{title}</h1>
+        <p>
+          Optional observability endpoints for the local Symphony runtime.
+          For a focused demo experience, open the standalone pomodoro app.
+        </p>
+        <nav class="nav-links" aria-label="Dashboard links">
+          <a href="/pomodoro">Open pomodoro app</a>
+          <a href="/api/v1/state">View raw state JSON</a>
+        </nav>
         <pre>#{body}</pre>
+      </body>
+    </html>
+    """
+  end
+
+  defp render_pomodoro_app do
+    ~S"""
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Pomodoro Timer</title>
+        <style>
+          :root {
+            color-scheme: light;
+            --surface: rgba(255, 255, 255, 0.92);
+            --surface-strong: rgba(255, 255, 255, 0.97);
+            --focus: #ef4444;
+            --break: #0f766e;
+            --ink: #172033;
+            --muted: #52607a;
+            --border: rgba(148, 163, 184, 0.25);
+            --shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+          }
+
+          * { box-sizing: border-box; }
+
+          body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            color: var(--ink);
+            background:
+              radial-gradient(circle at top, rgba(14, 165, 233, 0.16), transparent 40%),
+              linear-gradient(135deg, #f8fafc 0%, #e0f2fe 50%, #fdf2f8 100%);
+          }
+
+          a { color: inherit; }
+
+          .shell {
+            width: min(960px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 32px 0 48px;
+          }
+
+          .topbar {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            align-items: center;
+            margin-bottom: 28px;
+            flex-wrap: wrap;
+          }
+
+          .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            text-decoration: none;
+            font-weight: 700;
+            color: #1d4ed8;
+          }
+
+          .eyebrow {
+            margin: 0;
+            font-size: 0.82rem;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--muted);
+          }
+
+          h1 {
+            margin: 8px 0 12px;
+            font-size: clamp(2.2rem, 5vw, 3.8rem);
+            line-height: 1.05;
+          }
+
+          .subtitle {
+            margin: 0;
+            max-width: 44rem;
+            font-size: 1.05rem;
+            line-height: 1.6;
+            color: var(--muted);
+          }
+
+          .app-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.95fr);
+            gap: 20px;
+            margin-top: 28px;
+          }
+
+          .card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 28px;
+            box-shadow: var(--shadow);
+            backdrop-filter: blur(16px);
+          }
+
+          .timer-card {
+            padding: 28px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+          }
+
+          .phase-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 16px;
+            border-radius: 999px;
+            font-weight: 700;
+            background: rgba(239, 68, 68, 0.12);
+            color: var(--focus);
+            width: fit-content;
+          }
+
+          .phase-badge.break {
+            background: rgba(15, 118, 110, 0.12);
+            color: var(--break);
+          }
+
+          .timer-display {
+            font-size: clamp(4rem, 12vw, 7rem);
+            line-height: 1;
+            letter-spacing: -0.06em;
+            font-weight: 800;
+            margin: 0;
+          }
+
+          .status-copy {
+            margin: 0;
+            min-height: 1.6em;
+            color: var(--muted);
+            font-size: 1rem;
+          }
+
+          .progress-shell {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+          }
+
+          .progress-meta {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            font-size: 0.94rem;
+            color: var(--muted);
+          }
+
+          .progress-track {
+            position: relative;
+            overflow: hidden;
+            width: 100%;
+            height: 16px;
+            border-radius: 999px;
+            background: rgba(148, 163, 184, 0.22);
+          }
+
+          .progress-fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: linear-gradient(90deg, var(--focus), #fb7185);
+            transition: width 200ms linear, background 200ms ease;
+          }
+
+          .progress-fill.break {
+            background: linear-gradient(90deg, var(--break), #14b8a6);
+          }
+
+          .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+          }
+
+          button {
+            appearance: none;
+            border: none;
+            border-radius: 999px;
+            padding: 14px 20px;
+            font-size: 0.98rem;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
+          }
+
+          button:hover:not(:disabled) {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
+          }
+
+          button:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+          }
+
+          .primary { background: #111827; color: white; }
+          .secondary { background: #dbeafe; color: #1d4ed8; }
+          .ghost { background: rgba(148, 163, 184, 0.18); color: #334155; }
+
+          .stats {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 14px;
+          }
+
+          .stat {
+            border-radius: 20px;
+            padding: 18px;
+            background: var(--surface-strong);
+            border: 1px solid rgba(148, 163, 184, 0.22);
+          }
+
+          .stat-label {
+            display: block;
+            font-size: 0.82rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--muted);
+            margin-bottom: 10px;
+          }
+
+          .stat-value {
+            display: block;
+            font-size: 1.35rem;
+            font-weight: 800;
+          }
+
+          .settings-card {
+            padding: 24px;
+          }
+
+          .settings-card h2 {
+            margin: 0 0 8px;
+            font-size: 1.25rem;
+          }
+
+          .settings-card p {
+            margin: 0 0 20px;
+            color: var(--muted);
+            line-height: 1.55;
+          }
+
+          .settings-group {
+            display: grid;
+            gap: 16px;
+          }
+
+          .setting-block {
+            padding: 18px;
+            border-radius: 20px;
+            background: var(--surface-strong);
+            border: 1px solid rgba(148, 163, 184, 0.22);
+          }
+
+          .setting-block h3 {
+            margin: 0 0 14px;
+            font-size: 1rem;
+          }
+
+          .setting-fields {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 12px;
+          }
+
+          label {
+            display: grid;
+            gap: 8px;
+            font-size: 0.92rem;
+            font-weight: 600;
+          }
+
+          input[type="number"] {
+            width: 100%;
+            border-radius: 14px;
+            border: 1px solid rgba(148, 163, 184, 0.28);
+            padding: 12px 14px;
+            font-size: 1rem;
+            font: inherit;
+            color: inherit;
+            background: white;
+          }
+
+          .helper-copy {
+            margin-top: 16px;
+            font-size: 0.92rem;
+            color: var(--muted);
+            line-height: 1.5;
+          }
+
+          @media (max-width: 820px) {
+            .app-grid {
+              grid-template-columns: 1fr;
+            }
+
+            .shell {
+              width: min(100%, calc(100% - 20px));
+              padding-top: 24px;
+            }
+
+            .timer-card,
+            .settings-card {
+              padding: 22px;
+            }
+          }
+        </style>
+      </head>
+      <body>
+        <main class="shell">
+          <div class="topbar">
+            <a class="back-link" href="/">← Back to Symphony dashboard</a>
+            <p class="eyebrow">Standalone focus timer</p>
+          </div>
+
+          <section aria-label="Pomodoro intro">
+            <p class="eyebrow">Pomodoro web app</p>
+            <h1>Pomodoro Timer</h1>
+            <p class="subtitle">
+              Configure a focus session, start the countdown, and let the page roll into your
+              break automatically. Changing the duration inputs resets the timer so every run stays
+              predictable for demos and daily use.
+            </p>
+          </section>
+
+          <section class="app-grid" aria-label="Pomodoro timer experience">
+            <article class="card timer-card">
+              <span id="phaseBadge" class="phase-badge">Focus session</span>
+              <div>
+                <p id="timerDisplay" class="timer-display" aria-live="polite">25:00</p>
+                <p id="statusCopy" class="status-copy" aria-live="polite">
+                  Set your durations, then start a focus session.
+                </p>
+              </div>
+
+              <div class="progress-shell" aria-label="Timer progress">
+                <div class="progress-meta">
+                  <span>Progress</span>
+                  <span id="progressLabel">0%</span>
+                </div>
+                <div class="progress-track" role="presentation">
+                  <div id="progressFill" class="progress-fill"></div>
+                </div>
+              </div>
+
+              <div class="controls" aria-label="Timer controls">
+                <button id="startButton" class="primary" type="button">Start</button>
+                <button id="pauseButton" class="secondary" type="button">Pause</button>
+                <button id="resetButton" class="ghost" type="button">Reset</button>
+              </div>
+
+              <section class="stats" aria-label="Timer summary">
+                <div class="stat">
+                  <span class="stat-label">Current phase</span>
+                  <span id="phaseValue" class="stat-value">Focus</span>
+                </div>
+                <div class="stat">
+                  <span class="stat-label">Next up</span>
+                  <span id="nextPhaseValue" class="stat-value">Break</span>
+                </div>
+                <div class="stat">
+                  <span class="stat-label">Completed focus sessions</span>
+                  <span id="completedCount" class="stat-value">0</span>
+                </div>
+                <div class="stat">
+                  <span class="stat-label">Current duration</span>
+                  <span id="durationValue" class="stat-value">25:00</span>
+                </div>
+              </section>
+            </article>
+
+            <aside class="card settings-card">
+              <h2>Session settings</h2>
+              <p>
+                Use minutes and seconds so you can keep real pomodoro defaults or quickly dial in a
+                short demo. Every phase must be at least 1 second long.
+              </p>
+
+              <div class="settings-group">
+                <section class="setting-block" aria-labelledby="workSettingsTitle">
+                  <h3 id="workSettingsTitle">Focus duration</h3>
+                  <div class="setting-fields">
+                    <label>
+                      Minutes
+                      <input id="workMinutes" type="number" min="0" max="180" step="1" value="25">
+                    </label>
+                    <label>
+                      Seconds
+                      <input id="workSeconds" type="number" min="0" max="59" step="1" value="0">
+                    </label>
+                  </div>
+                </section>
+
+                <section class="setting-block" aria-labelledby="breakSettingsTitle">
+                  <h3 id="breakSettingsTitle">Break duration</h3>
+                  <div class="setting-fields">
+                    <label>
+                      Minutes
+                      <input id="breakMinutes" type="number" min="0" max="60" step="1" value="5">
+                    </label>
+                    <label>
+                      Seconds
+                      <input id="breakSeconds" type="number" min="0" max="59" step="1" value="0">
+                    </label>
+                  </div>
+                </section>
+              </div>
+
+              <p class="helper-copy">
+                Tip: for a quick walkthrough, try a 0m 3s focus session and a 0m 2s break. The app
+                will pause if you hit reset, and it will continue automatically when switching
+                between focus and break phases.
+              </p>
+            </aside>
+          </section>
+        </main>
+
+        <script>
+          (() => {
+            const elements = {
+              phaseBadge: document.getElementById('phaseBadge'),
+              timerDisplay: document.getElementById('timerDisplay'),
+              statusCopy: document.getElementById('statusCopy'),
+              progressLabel: document.getElementById('progressLabel'),
+              progressFill: document.getElementById('progressFill'),
+              phaseValue: document.getElementById('phaseValue'),
+              nextPhaseValue: document.getElementById('nextPhaseValue'),
+              completedCount: document.getElementById('completedCount'),
+              durationValue: document.getElementById('durationValue'),
+              startButton: document.getElementById('startButton'),
+              pauseButton: document.getElementById('pauseButton'),
+              resetButton: document.getElementById('resetButton'),
+              workMinutes: document.getElementById('workMinutes'),
+              workSeconds: document.getElementById('workSeconds'),
+              breakMinutes: document.getElementById('breakMinutes'),
+              breakSeconds: document.getElementById('breakSeconds')
+            };
+
+            const state = {
+              config: {
+                work: 25 * 60,
+                break: 5 * 60
+              },
+              phase: 'work',
+              remainingSeconds: 25 * 60,
+              isRunning: false,
+              intervalId: null,
+              endsAtMs: null,
+              completedFocusSessions: 0,
+              statusMessage: 'Set your durations, then start a focus session.'
+            };
+
+            const phaseMeta = {
+              work: { label: 'Focus', badge: 'Focus session', next: 'Break', className: '' },
+              break: { label: 'Break', badge: 'Break session', next: 'Focus', className: 'break' }
+            };
+
+            function formatSeconds(totalSeconds) {
+              const safeSeconds = Math.max(0, totalSeconds);
+              const minutes = Math.floor(safeSeconds / 60);
+              const seconds = safeSeconds % 60;
+              return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+            }
+
+            function readPhaseDuration(prefix) {
+              const minutesInput = elements[`${prefix}Minutes`];
+              const secondsInput = elements[`${prefix}Seconds`];
+              const minutes = Math.max(0, parseInt(minutesInput.value, 10) || 0);
+              const seconds = Math.max(0, Math.min(59, parseInt(secondsInput.value, 10) || 0));
+
+              minutesInput.value = String(minutes);
+              secondsInput.value = String(seconds);
+
+              return (minutes * 60) + seconds;
+            }
+
+            function syncDurations() {
+              const workDuration = readPhaseDuration('work');
+              const breakDuration = readPhaseDuration('break');
+
+              if (workDuration <= 0 || breakDuration <= 0) {
+                state.statusMessage = 'Each phase needs at least 1 second before the timer can run.';
+                render();
+                return false;
+              }
+
+              state.config.work = workDuration;
+              state.config.break = breakDuration;
+              return true;
+            }
+
+            function stopInterval() {
+              if (state.intervalId) {
+                window.clearInterval(state.intervalId);
+                state.intervalId = null;
+              }
+
+              state.isRunning = false;
+              state.endsAtMs = null;
+            }
+
+            function resetTimer(message = 'Timer reset to the start of your focus session.') {
+              stopInterval();
+              state.phase = 'work';
+              state.remainingSeconds = state.config.work;
+              state.statusMessage = message;
+              render();
+            }
+
+            function startTimer() {
+              if (!syncDurations() || state.isRunning) return;
+
+              state.isRunning = true;
+              state.endsAtMs = Date.now() + (state.remainingSeconds * 1000);
+              state.statusMessage =
+                state.phase === 'work'
+                  ? 'Focus mode is running.'
+                  : 'Break time is running.';
+
+              state.intervalId = window.setInterval(tickTimer, 250);
+              render();
+            }
+
+            function pauseTimer() {
+              if (!state.isRunning) return;
+
+              tickTimer();
+              stopInterval();
+              state.statusMessage = 'Timer paused.';
+              render();
+            }
+
+            function advancePhase() {
+              const finishedPhase = state.phase;
+
+              if (finishedPhase === 'work') {
+                state.completedFocusSessions += 1;
+                state.phase = 'break';
+                state.remainingSeconds = state.config.break;
+                state.statusMessage = 'Focus complete. Starting your break.';
+              } else {
+                state.phase = 'work';
+                state.remainingSeconds = state.config.work;
+                state.statusMessage = 'Break complete. Time to focus again.';
+              }
+
+              state.endsAtMs = Date.now() + (state.remainingSeconds * 1000);
+              render();
+            }
+
+            function tickTimer() {
+              if (!state.isRunning || !state.endsAtMs) return;
+
+              const nextRemaining = Math.max(0, Math.ceil((state.endsAtMs - Date.now()) / 1000));
+
+              if (nextRemaining === 0) {
+                advancePhase();
+                return;
+              }
+
+              state.remainingSeconds = nextRemaining;
+              render();
+            }
+
+            function render() {
+              const meta = phaseMeta[state.phase];
+              const totalPhaseSeconds = state.config[state.phase];
+              const elapsedSeconds = Math.max(0, totalPhaseSeconds - state.remainingSeconds);
+              const progressPercent =
+                totalPhaseSeconds > 0
+                  ? Math.min(100, Math.round((elapsedSeconds / totalPhaseSeconds) * 100))
+                  : 0;
+
+              elements.phaseBadge.textContent = meta.badge;
+              elements.phaseBadge.className = `phase-badge ${meta.className}`.trim();
+              elements.timerDisplay.textContent = formatSeconds(state.remainingSeconds);
+              elements.statusCopy.textContent = state.statusMessage;
+              elements.phaseValue.textContent = meta.label;
+              elements.nextPhaseValue.textContent = meta.next;
+              elements.completedCount.textContent = String(state.completedFocusSessions);
+              elements.durationValue.textContent = formatSeconds(totalPhaseSeconds);
+              elements.progressLabel.textContent = `${progressPercent}%`;
+              elements.progressFill.style.width = `${progressPercent}%`;
+              elements.progressFill.className = `progress-fill ${meta.className}`.trim();
+
+              elements.startButton.disabled = state.isRunning;
+              elements.pauseButton.disabled = !state.isRunning;
+            }
+
+            elements.startButton.addEventListener('click', startTimer);
+            elements.pauseButton.addEventListener('click', pauseTimer);
+            elements.resetButton.addEventListener('click', () => {
+              if (syncDurations()) {
+                resetTimer();
+              }
+            });
+
+            function handleDurationUpdate() {
+              if (syncDurations()) {
+                resetTimer('Durations updated. Ready for a new focus session.');
+              }
+            }
+
+            [elements.workMinutes, elements.workSeconds, elements.breakMinutes, elements.breakSeconds]
+              .forEach((input) => {
+                input.addEventListener('input', handleDurationUpdate);
+              });
+
+            resetTimer('Set your durations, then start a focus session.');
+          })();
+        </script>
       </body>
     </html>
     """

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -337,6 +337,15 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert status == 200
     assert Map.fetch!(headers, "content-type") =~ "text/html"
     assert body =~ "Symphony Dashboard"
+    assert body =~ "Open pomodoro app"
+
+    {status, headers, body} = http_request(port, "GET", "/pomodoro")
+    assert status == 200
+    assert Map.fetch!(headers, "content-type") =~ "text/html"
+    assert body =~ "Pomodoro Timer"
+    assert body =~ "Focus duration"
+    assert body =~ "Start"
+    assert body =~ "Break duration"
 
     {status, headers, body} = http_request(port, "GET", "/api/v1/state")
     assert status == 200
@@ -404,6 +413,10 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert %{"error" => %{"code" => "method_not_allowed"}} = Jason.decode!(body)
 
     {status, _headers, body} = http_request(port, "POST", "/", "")
+    assert status == 405
+    assert %{"error" => %{"code" => "method_not_allowed"}} = Jason.decode!(body)
+
+    {status, _headers, body} = http_request(port, "POST", "/pomodoro", "")
     assert status == 405
     assert %{"error" => %{"code" => "method_not_allowed"}} = Jason.decode!(body)
 


### PR DESCRIPTION
#### Context

JM-10 asks for a lightweight pomodoro web app without introducing a separate frontend or regressing Symphony's existing HTTP dashboard and JSON API.

#### TL;DR

*Add a standalone `/pomodoro` timer page to the Elixir HTTP server and document the new optional route.*

#### Summary

- Serve a self-contained pomodoro UI from `/pomodoro` and link to it from the existing dashboard.
- Support configurable focus and break durations plus start, pause, reset, and auto phase changes.
- Cover the new route in HTTP tests and document/spec-align the optional `/pomodoro` surface.

#### Alternatives

- Add a separate web app stack, but that would widen scope for a single local demo page.
- Replace the `/` dashboard, but keeping `/` observability-first preserves existing operator workflows.

#### Test Plan

- [x] `make -C elixir all`
- [x] Browser walkthrough on `http://127.0.0.1:4010/pomodoro` with `00:03` focus / `00:02` break durations.
- [x] `rg -n "/pomodoro|dashboard plus pomodoro|self-contained local demo" SPEC.md elixir/README.md`
