### PR TITLE
Escape dashboard HTML payload before rendering

### DIFF
--- a/elixir/lib/symphony_elixir/http_server.ex
+++ b/elixir/lib/symphony_elixir/http_server.ex
@@ -411,6 +411,7 @@ defmodule SymphonyElixir.HttpServer do
     payload = state_payload(orchestrator, snapshot_timeout_ms)
     title = "Symphony Dashboard"
     body = Jason.encode!(payload, pretty: true)
+    escaped_body = escape_html(body)
 
     """
     <!doctype html>
@@ -426,10 +427,19 @@ defmodule SymphonyElixir.HttpServer do
       </head>
       <body>
         <h1>#{title}</h1>
-        <pre>#{body}</pre>
+        <pre>#{escaped_body}</pre>
       </body>
     </html>
     """
+  end
+
+  defp escape_html(value) when is_binary(value) do
+    value
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&#39;")
   end
 
   defp parse_host({_, _, _, _} = ip), do: {:ok, ip}

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -375,6 +375,54 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert %{"coalesced" => false, "operations" => ["poll", "reconcile"], "queued" => true} = Jason.decode!(body)
   end
 
+  test "http server escapes html-sensitive characters in rendered dashboard payload" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    orchestrator_name = Module.concat(__MODULE__, :EscapingHttpOrchestrator)
+    server_name = Module.concat(__MODULE__, :EscapingHttpServer)
+    {:ok, orchestrator_pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    {:ok, server_pid} =
+      HttpServer.start_link(
+        name: server_name,
+        host: "127.0.0.1",
+        port: 0,
+        orchestrator: orchestrator_name,
+        snapshot_timeout_ms: 1_000
+      )
+
+    on_exit(fn ->
+      if Process.alive?(server_pid), do: Process.exit(server_pid, :normal)
+      if Process.alive?(orchestrator_pid), do: Process.exit(orchestrator_pid, :normal)
+    end)
+
+    running_entry = %{
+      pid: self(),
+      ref: make_ref(),
+      identifier: "MT-897",
+      issue: %Issue{id: "issue-html", identifier: "MT-897", state: "In Progress"},
+      session_id: "thread-html",
+      turn_count: 7,
+      codex_app_server_pid: nil,
+      last_codex_message: "<script>window.xssed=1</script>",
+      last_codex_timestamp: nil,
+      last_codex_event: :notification,
+      codex_input_tokens: 4,
+      codex_output_tokens: 8,
+      codex_total_tokens: 12,
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(orchestrator_pid, fn state ->
+      %{state | running: %{"issue-html" => running_entry}, retry_attempts: %{}}
+    end)
+
+    port = wait_for_bound_port(server_name)
+    {status, _headers, body} = http_request(port, "GET", "/")
+    assert status == 200
+    refute String.contains?(body, "<script>window.xssed=1</script>")
+    assert body =~ "&lt;script&gt;window.xssed=1&lt;/script&gt;"
+  end
+
   test "http server returns method, parse, timeout, and unavailable errors" do
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
     server_name = Module.concat(__MODULE__, :ErrorHttpServer)


### PR DESCRIPTION
#### Context

Prevent stored XSS in the dashboard root HTML endpoint by escaping JSON payload characters before rendering.

#### TL;DR

Escape dashboard JSON output before injecting it into the `<pre>` element.

#### Summary

- Add HTML escaping in `SymphonyElixir.HttpServer.render_dashboard/3`.
- Add regression coverage to verify `<script>` in dashboard payload is escaped.
- Keep existing dashboard JSON payload shape for safe clients.

#### Alternatives

- Continue rendering raw JSON and rely on downstream consumers; this remains unsafe for script injection.

#### Test Plan

- [x] `mix test test/symphony_elixir/extensions_test.exs`
- [ ] `make -C elixir all`
