### PR TITLE
Silence noisy Elixir make-all task output

### DIFF
--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -26,6 +26,10 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Workspace
         ]
       ],
+      test_ignore_filters: [
+        "test/support/snapshot_support.exs",
+        "test/support/test_support.exs"
+      ],
       dialyzer: [
         plt_add_apps: [:mix]
       ],

--- a/elixir/test/mix/tasks/pr_body_check_test.exs
+++ b/elixir/test/mix/tasks/pr_body_check_test.exs
@@ -278,9 +278,11 @@ defmodule Mix.Tasks.PrBody.CheckTest do
       write_template!(@template)
       File.write!("body.md", "#### Context\nContext text.")
 
-      assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
-        Check.run(["lint", "--file", "body.md"])
-      end
+      capture_io(:stderr, fn ->
+        assert_raise Mix.Error, ~r/PR body format invalid/, fn ->
+          Check.run(["lint", "--file", "body.md"])
+        end
+      end)
     end)
   end
 

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -81,12 +81,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       exit 0
       """,
       fn log_path ->
-        output =
-          capture_io(fn ->
+        {output, error_output} =
+          capture_task_output(fn ->
             BeforeRemove.run([])
           end)
 
         assert output =~ "Closed PR #101 for branch feature/workpad"
+        assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
 
         log = File.read!(log_path)
 
@@ -103,7 +104,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
     with_fake_gh(fn log_path ->
       File.write!(log_path, "")
 
-      BeforeRemove.run(["--branch", "feature/workpad"])
+      {output, error_output} =
+        capture_task_output(fn ->
+          BeforeRemove.run(["--branch", "feature/workpad"])
+        end)
+
+      assert output =~ "Closed PR #101 for branch feature/workpad"
+      assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
 
       log = File.read!(log_path)
 
@@ -112,12 +119,13 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       assert log =~ "pr close 101 --repo openai/symphony"
       assert log =~ "pr close 102 --repo openai/symphony"
 
-      error_output =
-        capture_io(:stderr, fn ->
+      {second_output, error_output} =
+        capture_task_output(fn ->
           Mix.Task.reenable("workspace.before_remove")
           BeforeRemove.run(["--branch", "feature/workpad"])
         end)
 
+      assert second_output =~ "Closed PR #101 for branch feature/workpad"
       assert error_output =~ "Failed to close PR #102 for branch feature/workpad"
     end)
   end
@@ -354,5 +362,29 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       File.cd!(original_cwd)
       File.rm_rf!(root)
     end
+  end
+
+  defp capture_task_output(fun) do
+    parent = self()
+    ref = make_ref()
+
+    error_output =
+      capture_io(:stderr, fn ->
+        output =
+          capture_io(fn ->
+            fun.()
+          end)
+
+        send(parent, {ref, output})
+      end)
+
+    output =
+      receive do
+        {^ref, output} -> output
+      after
+        1_000 -> flunk("Timed out waiting for captured task output")
+      end
+
+    {output, error_output}
   end
 end


### PR DESCRIPTION
#### Context

Expected Mix task stderr/stdout and Elixir 1.19 helper-file warnings made `make -C elixir all` look broken even when it passed.

#### TL;DR

*Silence expected task-test output and ignore helper files so `make -C elixir all` stays clean.*

#### Summary

- Capture expected stdout and stderr in Mix task tests instead of leaking them into passing runs.
- Add a helper for `workspace.before_remove` tests to assert both streams without noisy console output.
- Ignore `test/support/*.exs` in Mix test loading to remove Elixir 1.19 cover warnings.

#### Alternatives

- Leave the noisy output in place, but that keeps `make -C elixir all` looking unhealthy and hides real failures.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mix test test/mix/tasks/pr_body_check_test.exs`
- [x] `cd elixir && mix test test/mix/tasks/workspace_before_remove_test.exs`
