### PR TITLE
Align workflow config spec with schema behavior

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -273,7 +273,7 @@ Fields:
   - Derive from `issue.identifier` by replacing any character not in `[A-Za-z0-9._-]` with `_`.
   - Use the sanitized value for the workspace directory name.
 - `Normalized Issue State`
-  - Compare states after `trim` + `lowercase`.
+  - Compare states after `lowercase`.
 - `Session ID`
   - Compose from coding-agent `thread_id` and `turn_id` as `<thread_id>-<turn_id>`.
 
@@ -351,9 +351,9 @@ Fields:
   - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
 - `project_slug` (string)
   - Required for dispatch when `tracker.kind == "linear"`.
-- `active_states` (list of strings or comma-separated string)
+- `active_states` (list of strings)
   - Default: `Todo`, `In Progress`
-- `terminal_states` (list of strings or comma-separated string)
+- `terminal_states` (list of strings)
   - Default: `Closed`, `Cancelled`, `Canceled`, `Duplicate`, `Done`
 
 #### 5.3.2 `polling` (object)
@@ -410,7 +410,7 @@ Fields:
   - Changes should be re-applied at runtime and affect future retry scheduling.
 - `max_concurrent_agents_by_state` (map `state_name -> positive integer`)
   - Default: empty map.
-  - State keys are normalized (`trim` + `lowercase`) for lookup.
+  - State keys are normalized (`lowercase`) for lookup.
   - Invalid entries (non-positive or non-numeric) are ignored.
 
 #### 5.3.6 `codex` (object)
@@ -555,8 +555,8 @@ This section is intentionally redundant so a coding agent can implement the conf
 - `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
 - `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
 - `tracker.project_slug`: string, required when `tracker.kind=linear`
-- `tracker.active_states`: list/string, default `Todo, In Progress`
-- `tracker.terminal_states`: list/string, default `Closed, Cancelled, Canceled, Duplicate, Done`
+- `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
+- `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path, default `<system-temp>/symphony_workspaces`
 - `hooks.after_create`: shell script or null


### PR DESCRIPTION
#### Context

The schema and tests now treat tracker state lists as YAML lists and only lowercase
state-limit keys, but `SPEC.md` still documented older and stricter behavior.

#### TL;DR

*Align `SPEC.md` with the current workflow config and state normalization behavior.*

#### Summary

- document tracker `active_states` and `terminal_states` as YAML string lists
- update the cheat sheet defaults to use list examples instead of CSV strings
- remove trim-based state normalization language from the spec

#### Alternatives

- restore support for comma-separated tracker state strings in the schema
- keep trim-based normalization in the spec and change the implementation

#### Test Plan

- [x] `make -C elixir all`
- [x] Docs-only diff reviewed against current schema and tests
