### PR TITLE
Allow network access for package-installing workflow turns

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -119,6 +119,9 @@ Notes:
 - When `codex.turn_sandbox_policy` is set explicitly, Symphony passes the map through to Codex
   unchanged. Compatibility then depends on the targeted Codex app-server version rather than local
   Symphony validation.
+- Workflows that run package managers or other commands that resolve external hosts should set
+  `networkAccess: true` in `codex.turn_sandbox_policy`; otherwise DNS/network access may be denied
+  by the Codex turn sandbox.
 - `agent.max_turns` caps how many back-to-back Codex turns Symphony will run in a single agent
   invocation when a turn completes normally but the issue is still in an active state. Default: `20`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -34,6 +34,7 @@ codex:
   thread_sandbox: workspace-write
   turn_sandbox_policy:
     type: workspaceWrite
+    networkAccess: true
 ---
 
 You are working on a Linear ticket `{{ issue.identifier }}`


### PR DESCRIPTION
#### Context

Brix oaipkg installs in Symphony-launched FSS runs need DNS/network access, but the workflow turn sandbox did not enable it.

#### TL;DR

*Allow Symphony workflow turns to use network/DNS for package installs.*

#### Summary

- Add `networkAccess: true` to the workflow turn sandbox policy.
- Document the setting for package-manager and external-host workflows.

#### Alternatives

- Leave safer code defaults unchanged and scope the allowance to this workflow.

#### Test Plan

- [x] `/usr/bin/env mix run -e IO.inspect(...)` before and after config change
- [x] `/usr/bin/env mix specs.check`
- [x] `/usr/bin/env mix test test/symphony_elixir/workspace_and_config_test.exs`
- [x] `/usr/bin/env make all MIX="/usr/bin/env mix"`
