### PR TITLE
Surface input-blocked Symphony sessions

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -26,6 +26,11 @@ skills can make raw Linear GraphQL calls.
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
 
+If Codex reports that operator input, approval, or MCP elicitation is required, Symphony keeps the
+issue claimed and exposes it as blocked in the runtime state, JSON API, and dashboard. Blocked
+entries are in memory only; restarting the orchestrator clears that blocked map, so any still-active
+Linear issue can become a dispatch candidate again after restart.
+
 ## How to use it
 
 1. Make sure your codebase is set up to work well with agents: see

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -1059,6 +1059,8 @@ defmodule SymphonyElixir.Codex.AppServer do
     Port.command(port, line)
   end
 
+  defp needs_input?("mcpServer/elicitation/request", payload) when is_map(payload), do: true
+
   defp needs_input?(method, payload)
        when is_binary(method) and is_map(payload) do
     String.starts_with?(method, "turn/") && input_required_method?(method, payload)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -36,6 +36,7 @@ defmodule SymphonyElixir.Orchestrator do
       running: %{},
       completed: MapSet.new(),
       claimed: MapSet.new(),
+      blocked: %{},
       retry_attempts: %{},
       codex_totals: nil,
       codex_rate_limits: nil
@@ -129,32 +130,7 @@ defmodule SymphonyElixir.Orchestrator do
         state = record_session_completion_totals(state, running_entry)
         session_id = running_entry_session_id(running_entry)
 
-        state =
-          case reason do
-            :normal ->
-              Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
-
-              state
-              |> complete_issue(issue_id)
-              |> schedule_issue_retry(issue_id, 1, %{
-                identifier: running_entry.identifier,
-                delay_type: :continuation,
-                worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
-              })
-
-            _ ->
-              Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
-
-              next_attempt = next_retry_attempt_from_running(running_entry)
-
-              schedule_issue_retry(state, issue_id, next_attempt, %{
-                identifier: running_entry.identifier,
-                error: "agent exited: #{inspect(reason)}",
-                worker_host: Map.get(running_entry, :worker_host),
-                workspace_path: Map.get(running_entry, :workspace_path)
-              })
-          end
+        state = handle_agent_down(reason, state, issue_id, running_entry, session_id)
 
         Logger.info("Agent task finished for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}")
 
@@ -221,8 +197,53 @@ defmodule SymphonyElixir.Orchestrator do
     {:noreply, state}
   end
 
+  defp handle_agent_down(:normal, state, issue_id, running_entry, session_id) do
+    Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
+
+    state
+    |> complete_issue(issue_id)
+    |> schedule_issue_retry(issue_id, 1, %{
+      identifier: running_entry.identifier,
+      delay_type: :continuation,
+      worker_host: Map.get(running_entry, :worker_host),
+      workspace_path: Map.get(running_entry, :workspace_path)
+    })
+  end
+
+  defp handle_agent_down(reason, state, issue_id, running_entry, session_id) do
+    if input_required_blocker?(running_entry) do
+      block_input_required_agent_down(state, issue_id, running_entry, session_id, reason)
+    else
+      retry_agent_down(state, issue_id, running_entry, session_id, reason)
+    end
+  end
+
+  defp block_input_required_agent_down(state, issue_id, running_entry, session_id, reason) do
+    error = blocker_error(running_entry, "agent exited: #{inspect(reason)}")
+
+    Logger.warning("Agent task blocked for issue_id=#{issue_id} issue_identifier=#{running_entry.identifier} session_id=#{session_id}: #{error}")
+
+    block_issue_from_entry(state, issue_id, running_entry, error)
+  end
+
+  defp retry_agent_down(state, issue_id, running_entry, session_id, reason) do
+    Logger.warning("Agent task exited for issue_id=#{issue_id} session_id=#{session_id} reason=#{inspect(reason)}; scheduling retry")
+
+    next_attempt = next_retry_attempt_from_running(running_entry)
+
+    schedule_issue_retry(state, issue_id, next_attempt, %{
+      identifier: running_entry.identifier,
+      error: "agent exited: #{inspect(reason)}",
+      worker_host: Map.get(running_entry, :worker_host),
+      workspace_path: Map.get(running_entry, :workspace_path)
+    })
+  end
+
   defp maybe_dispatch(%State{} = state) do
-    state = reconcile_running_issues(state)
+    state =
+      state
+      |> reconcile_running_issues()
+      |> reconcile_blocked_issues()
 
     with :ok <- Config.validate!(),
          {:ok, issues} <- Tracker.fetch_candidate_issues(),
@@ -291,6 +312,30 @@ defmodule SymphonyElixir.Orchestrator do
 
         {:error, reason} ->
           Logger.debug("Failed to refresh running issue states: #{inspect(reason)}; keeping active workers")
+
+          state
+      end
+    end
+  end
+
+  defp reconcile_blocked_issues(%State{} = state) do
+    blocked_ids = Map.keys(state.blocked)
+
+    if blocked_ids == [] do
+      state
+    else
+      case Tracker.fetch_issue_states_by_ids(blocked_ids) do
+        {:ok, issues} ->
+          issues
+          |> reconcile_blocked_issue_states(
+            state,
+            active_state_set(),
+            terminal_state_set()
+          )
+          |> reconcile_missing_blocked_issue_ids(blocked_ids, issues)
+
+        {:error, reason} ->
+          Logger.debug("Failed to refresh blocked issue states: #{inspect(reason)}; keeping blocked issues")
 
           state
       end
@@ -368,6 +413,39 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp reconcile_issue_state(_issue, state, _active_states, _terminal_states), do: state
 
+  defp reconcile_blocked_issue_states([], state, _active_states, _terminal_states), do: state
+
+  defp reconcile_blocked_issue_states([issue | rest], state, active_states, terminal_states) do
+    reconcile_blocked_issue_states(
+      rest,
+      reconcile_blocked_issue_state(issue, state, active_states, terminal_states),
+      active_states,
+      terminal_states
+    )
+  end
+
+  defp reconcile_blocked_issue_state(%Issue{} = issue, state, active_states, terminal_states) do
+    cond do
+      terminal_issue_state?(issue.state, terminal_states) ->
+        Logger.info("Blocked issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; releasing block")
+        cleanup_issue_workspace(issue.identifier, blocked_issue_worker_host(state, issue.id))
+        release_issue_claim(state, issue.id)
+
+      !issue_routable_to_worker?(issue) ->
+        Logger.info("Blocked issue no longer routed to this worker: #{issue_context(issue)} assignee=#{inspect(issue.assignee_id)}; releasing block")
+        release_issue_claim(state, issue.id)
+
+      active_issue_state?(issue.state, active_states) ->
+        refresh_blocked_issue_state(state, issue)
+
+      true ->
+        Logger.info("Blocked issue moved to non-active state: #{issue_context(issue)} state=#{issue.state}; releasing block")
+        release_issue_claim(state, issue.id)
+    end
+  end
+
+  defp reconcile_blocked_issue_state(_issue, state, _active_states, _terminal_states), do: state
+
   defp reconcile_missing_running_issue_ids(%State{} = state, requested_issue_ids, issues)
        when is_list(requested_issue_ids) and is_list(issues) do
     visible_issue_ids =
@@ -389,6 +467,28 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp reconcile_missing_running_issue_ids(state, _requested_issue_ids, _issues), do: state
+
+  defp reconcile_missing_blocked_issue_ids(%State{} = state, requested_issue_ids, issues)
+       when is_list(requested_issue_ids) and is_list(issues) do
+    visible_issue_ids =
+      issues
+      |> Enum.flat_map(fn
+        %Issue{id: issue_id} when is_binary(issue_id) -> [issue_id]
+        _ -> []
+      end)
+      |> MapSet.new()
+
+    Enum.reduce(requested_issue_ids, state, fn issue_id, state_acc ->
+      if MapSet.member?(visible_issue_ids, issue_id) do
+        state_acc
+      else
+        Logger.info("Blocked issue no longer visible during state refresh: issue_id=#{issue_id}; releasing block")
+        release_issue_claim(state_acc, issue_id)
+      end
+    end)
+  end
+
+  defp reconcile_missing_blocked_issue_ids(state, _requested_issue_ids, _issues), do: state
 
   defp log_missing_running_issue(%State{} = state, issue_id) when is_binary(issue_id) do
     case Map.get(state.running, issue_id) do
@@ -412,6 +512,16 @@ defmodule SymphonyElixir.Orchestrator do
     end
   end
 
+  defp refresh_blocked_issue_state(%State{} = state, %Issue{} = issue) do
+    case Map.get(state.blocked, issue.id) do
+      %{issue: _} = blocked_entry ->
+        %{state | blocked: Map.put(state.blocked, issue.id, %{blocked_entry | issue: issue})}
+
+      _ ->
+        state
+    end
+  end
+
   defp terminate_running_issue(%State{} = state, issue_id, cleanup_workspace) do
     case Map.get(state.running, issue_id) do
       nil ->
@@ -425,18 +535,13 @@ defmodule SymphonyElixir.Orchestrator do
           cleanup_issue_workspace(identifier, worker_host)
         end
 
-        if is_pid(pid) do
-          terminate_task(pid)
-        end
-
-        if is_reference(ref) do
-          Process.demonitor(ref, [:flush])
-        end
+        stop_running_task(pid, ref)
 
         %{
           state
           | running: Map.delete(state.running, issue_id),
             claimed: MapSet.delete(state.claimed, issue_id),
+            blocked: Map.delete(state.blocked, issue_id),
             retry_attempts: Map.delete(state.retry_attempts, issue_id)
         }
 
@@ -471,16 +576,26 @@ defmodule SymphonyElixir.Orchestrator do
       identifier = Map.get(running_entry, :identifier, issue_id)
       session_id = running_entry_session_id(running_entry)
 
-      Logger.warning("Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff")
+      if input_required_blocker?(running_entry) do
+        error = blocker_error(running_entry, "stalled for #{elapsed_ms}ms after Codex requested operator input")
 
-      next_attempt = next_retry_attempt_from_running(running_entry)
+        Logger.warning("Issue blocked: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; #{error}")
 
-      state
-      |> terminate_running_issue(issue_id, false)
-      |> schedule_issue_retry(issue_id, next_attempt, %{
-        identifier: identifier,
-        error: "stalled for #{elapsed_ms}ms without codex activity"
-      })
+        state
+        |> record_session_completion_totals(running_entry)
+        |> stop_and_block_issue(issue_id, running_entry, error)
+      else
+        Logger.warning("Issue stalled: issue_id=#{issue_id} issue_identifier=#{identifier} session_id=#{session_id} elapsed_ms=#{elapsed_ms}; restarting with backoff")
+
+        next_attempt = next_retry_attempt_from_running(running_entry)
+
+        state
+        |> terminate_running_issue(issue_id, false)
+        |> schedule_issue_retry(issue_id, next_attempt, %{
+          identifier: identifier,
+          error: "stalled for #{elapsed_ms}ms without codex activity"
+        })
+      end
     else
       state
     end
@@ -504,6 +619,40 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp last_activity_timestamp(_running_entry), do: nil
 
+  defp input_required_blocker?(running_entry) when is_map(running_entry) do
+    Map.get(running_entry, :last_codex_event) in [:turn_input_required, :approval_required] or
+      codex_message_method(Map.get(running_entry, :last_codex_message)) ==
+        "mcpServer/elicitation/request"
+  end
+
+  defp input_required_blocker?(_running_entry), do: false
+
+  defp blocker_error(running_entry, fallback) when is_map(running_entry) do
+    case Map.get(running_entry, :last_codex_event) do
+      :turn_input_required ->
+        "codex turn requires operator input"
+
+      :approval_required ->
+        "codex turn requires approval"
+
+      _ ->
+        if codex_message_method(Map.get(running_entry, :last_codex_message)) ==
+             "mcpServer/elicitation/request" do
+          "codex MCP elicitation requires operator input"
+        else
+          fallback
+        end
+    end
+  end
+
+  defp blocker_error(_running_entry, fallback), do: fallback
+
+  defp codex_message_method(%{message: %{"method" => method}}) when is_binary(method), do: method
+  defp codex_message_method(%{message: %{method: method}}) when is_binary(method), do: method
+  defp codex_message_method(%{"method" => method}) when is_binary(method), do: method
+  defp codex_message_method(%{method: method}) when is_binary(method), do: method
+  defp codex_message_method(_message), do: nil
+
   defp terminate_task(pid) when is_pid(pid) do
     case Task.Supervisor.terminate_child(SymphonyElixir.TaskSupervisor, pid) do
       :ok ->
@@ -515,6 +664,47 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp terminate_task(_pid), do: :ok
+
+  defp stop_running_task(pid, ref) do
+    if is_pid(pid) do
+      terminate_task(pid)
+    end
+
+    if is_reference(ref) do
+      Process.demonitor(ref, [:flush])
+    end
+
+    :ok
+  end
+
+  defp stop_and_block_issue(%State{} = state, issue_id, running_entry, error) do
+    stop_running_task(Map.get(running_entry, :pid), Map.get(running_entry, :ref))
+    block_issue_from_entry(state, issue_id, running_entry, error)
+  end
+
+  defp block_issue_from_entry(%State{} = state, issue_id, running_entry, error) do
+    blocked_entry = %{
+      issue_id: issue_id,
+      identifier: Map.get(running_entry, :identifier, issue_id),
+      issue: Map.get(running_entry, :issue),
+      worker_host: Map.get(running_entry, :worker_host),
+      workspace_path: Map.get(running_entry, :workspace_path),
+      session_id: running_entry_session_id(running_entry),
+      error: error,
+      blocked_at: DateTime.utc_now(),
+      last_codex_message: Map.get(running_entry, :last_codex_message),
+      last_codex_event: Map.get(running_entry, :last_codex_event),
+      last_codex_timestamp: Map.get(running_entry, :last_codex_timestamp)
+    }
+
+    %{
+      state
+      | running: Map.delete(state.running, issue_id),
+        retry_attempts: Map.delete(state.retry_attempts, issue_id),
+        claimed: MapSet.put(state.claimed, issue_id),
+        blocked: Map.put(state.blocked, issue_id, blocked_entry)
+    }
+  end
 
   defp choose_issues(issues, state) do
     active_states = active_state_set()
@@ -553,7 +743,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp should_dispatch_issue?(
          %Issue{} = issue,
-         %State{running: running, claimed: claimed} = state,
+         %State{running: running, claimed: claimed, blocked: blocked} = state,
          active_states,
          terminal_states
        ) do
@@ -561,6 +751,7 @@ defmodule SymphonyElixir.Orchestrator do
       !todo_issue_blocked_by_non_terminal?(issue, terminal_states) and
       !MapSet.member?(claimed, issue.id) and
       !Map.has_key?(running, issue.id) and
+      !Map.has_key?(blocked, issue.id) and
       available_slots(state) > 0 and
       state_slots_available?(issue, running) and
       worker_slots_available?(state)
@@ -879,6 +1070,12 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp cleanup_issue_workspace(_identifier, _worker_host), do: :ok
 
+  defp blocked_issue_worker_host(%State{} = state, issue_id) do
+    state.blocked
+    |> Map.get(issue_id, %{})
+    |> Map.get(:worker_host)
+  end
+
   defp run_terminal_workspace_cleanup do
     case Tracker.fetch_issues_by_states(Config.settings!().tracker.terminal_states) do
       {:ok, issues} ->
@@ -922,7 +1119,12 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp release_issue_claim(%State{} = state, issue_id) do
-    %{state | claimed: MapSet.delete(state.claimed, issue_id)}
+    %{
+      state
+      | claimed: MapSet.delete(state.claimed, issue_id),
+        blocked: Map.delete(state.blocked, issue_id),
+        retry_attempts: Map.delete(state.retry_attempts, issue_id)
+    }
   end
 
   defp retry_delay(attempt, metadata) when is_integer(attempt) and attempt > 0 and is_map(metadata) do
@@ -1140,10 +1342,29 @@ defmodule SymphonyElixir.Orchestrator do
         }
       end)
 
+    blocked =
+      state.blocked
+      |> Enum.map(fn {issue_id, metadata} ->
+        %{
+          issue_id: issue_id,
+          identifier: Map.get(metadata, :identifier),
+          state: blocked_issue_state(metadata),
+          worker_host: Map.get(metadata, :worker_host),
+          workspace_path: Map.get(metadata, :workspace_path),
+          session_id: Map.get(metadata, :session_id),
+          error: Map.get(metadata, :error),
+          blocked_at: Map.get(metadata, :blocked_at),
+          last_codex_timestamp: Map.get(metadata, :last_codex_timestamp),
+          last_codex_message: Map.get(metadata, :last_codex_message),
+          last_codex_event: Map.get(metadata, :last_codex_event)
+        }
+      end)
+
     {:reply,
      %{
        running: running,
        retrying: retrying,
+       blocked: blocked,
        codex_totals: state.codex_totals,
        rate_limits: Map.get(state, :codex_rate_limits),
        polling: %{
@@ -1168,6 +1389,9 @@ defmodule SymphonyElixir.Orchestrator do
        operations: ["poll", "reconcile"]
      }, state}
   end
+
+  defp blocked_issue_state(%{issue: %Issue{state: state}}), do: state
+  defp blocked_issue_state(_metadata), do: nil
 
   defp integrate_codex_update(running_entry, %{event: event, timestamp: timestamp} = update) do
     token_delta = extract_token_delta(running_entry, update)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -198,16 +198,20 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp handle_agent_down(:normal, state, issue_id, running_entry, session_id) do
-    Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
+    if input_required_blocker?(running_entry) do
+      block_input_required_agent_down(state, issue_id, running_entry, session_id, :normal)
+    else
+      Logger.info("Agent task completed for issue_id=#{issue_id} session_id=#{session_id}; scheduling active-state continuation check")
 
-    state
-    |> complete_issue(issue_id)
-    |> schedule_issue_retry(issue_id, 1, %{
-      identifier: running_entry.identifier,
-      delay_type: :continuation,
-      worker_host: Map.get(running_entry, :worker_host),
-      workspace_path: Map.get(running_entry, :workspace_path)
-    })
+      state
+      |> complete_issue(issue_id)
+      |> schedule_issue_retry(issue_id, 1, %{
+        identifier: running_entry.identifier,
+        delay_type: :continuation,
+        worker_host: Map.get(running_entry, :worker_host),
+        workspace_path: Map.get(running_entry, :workspace_path)
+      })
+    end
   end
 
   defp handle_agent_down(reason, state, issue_id, running_entry, session_id) do
@@ -564,8 +568,16 @@ defmodule SymphonyElixir.Orchestrator do
         now = DateTime.utc_now()
 
         Enum.reduce(state.running, state, fn {issue_id, running_entry}, state_acc ->
-          restart_stalled_issue(state_acc, issue_id, running_entry, now, timeout_ms)
+          maybe_restart_stalled_issue(state_acc, issue_id, running_entry, now, timeout_ms)
         end)
+    end
+  end
+
+  defp maybe_restart_stalled_issue(state, issue_id, running_entry, now, timeout_ms) do
+    if Map.has_key?(state.blocked, issue_id) do
+      state
+    else
+      restart_stalled_issue(state, issue_id, running_entry, now, timeout_ms)
     end
   end
 
@@ -621,31 +633,61 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp input_required_blocker?(running_entry) when is_map(running_entry) do
     Map.get(running_entry, :last_codex_event) in [:turn_input_required, :approval_required] or
+      not is_nil(input_required_completion_outcome(Map.get(running_entry, :completion))) or
       codex_message_method(Map.get(running_entry, :last_codex_message)) ==
         "mcpServer/elicitation/request"
   end
 
   defp input_required_blocker?(_running_entry), do: false
 
-  defp blocker_error(running_entry, fallback) when is_map(running_entry) do
-    case Map.get(running_entry, :last_codex_event) do
-      :turn_input_required ->
-        "codex turn requires operator input"
+  defp input_required_completion_outcome(completion) when is_map(completion) do
+    outcome = Map.get(completion, :outcome) || Map.get(completion, "outcome")
+    normalize_input_required_outcome(outcome)
+  end
 
-      :approval_required ->
-        "codex turn requires approval"
+  defp input_required_completion_outcome(_completion), do: nil
 
-      _ ->
-        if codex_message_method(Map.get(running_entry, :last_codex_message)) ==
-             "mcpServer/elicitation/request" do
-          "codex MCP elicitation requires operator input"
-        else
-          fallback
-        end
+  defp normalize_input_required_outcome(outcome)
+       when outcome in [:input_required, :needs_input, :approval_required],
+       do: outcome
+
+  defp normalize_input_required_outcome(outcome) when is_binary(outcome) do
+    case outcome do
+      "input_required" -> :input_required
+      "needs_input" -> :needs_input
+      "approval_required" -> :approval_required
+      _ -> nil
     end
   end
 
+  defp normalize_input_required_outcome(_outcome), do: nil
+
+  defp blocker_error(running_entry, fallback) when is_map(running_entry) do
+    codex_event_blocker_error(Map.get(running_entry, :last_codex_event)) ||
+      completion_blocker_error(Map.get(running_entry, :completion)) ||
+      codex_message_blocker_error(Map.get(running_entry, :last_codex_message)) ||
+      fallback
+  end
+
   defp blocker_error(_running_entry, fallback), do: fallback
+
+  defp codex_event_blocker_error(:turn_input_required), do: "codex turn requires operator input"
+  defp codex_event_blocker_error(:approval_required), do: "codex turn requires approval"
+  defp codex_event_blocker_error(_event), do: nil
+
+  defp completion_blocker_error(completion) do
+    case input_required_completion_outcome(completion) do
+      outcome when outcome in [:input_required, :needs_input] -> "codex turn requires operator input"
+      :approval_required -> "codex turn requires approval"
+      nil -> nil
+    end
+  end
+
+  defp codex_message_blocker_error(message) do
+    if codex_message_method(message) == "mcpServer/elicitation/request" do
+      "codex MCP elicitation requires operator input"
+    end
+  end
 
   defp codex_message_method(%{message: %{"method" => method}}) when is_binary(method), do: method
   defp codex_message_method(%{message: %{method: method}}) when is_binary(method), do: method

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -92,6 +92,12 @@ defmodule SymphonyElixirWeb.DashboardLive do
           </article>
 
           <article class="metric-card">
+            <p class="metric-label">Blocked</p>
+            <p class="metric-value numeric"><%= @payload.counts.blocked %></p>
+            <p class="metric-detail">Issues paused for operator input or approval.</p>
+          </article>
+
+          <article class="metric-card">
             <p class="metric-label">Total tokens</p>
             <p class="metric-value numeric"><%= format_int(@payload.codex_totals.total_tokens) %></p>
             <p class="metric-detail numeric">
@@ -199,6 +205,80 @@ defmodule SymphonyElixirWeb.DashboardLive do
                         <span class="muted">In <%= format_int(entry.tokens.input_tokens) %> / Out <%= format_int(entry.tokens.output_tokens) %></span>
                       </div>
                     </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          <% end %>
+        </section>
+
+        <section class="section-card">
+          <div class="section-header">
+            <div>
+              <h2 class="section-title">Blocked sessions</h2>
+              <p class="section-copy">Issues paused because Codex requested operator input or approval.</p>
+            </div>
+          </div>
+
+          <%= if @payload.blocked == [] do %>
+            <p class="empty-state">No blocked sessions.</p>
+          <% else %>
+            <div class="table-wrap">
+              <table class="data-table" style="min-width: 760px;">
+                <thead>
+                  <tr>
+                    <th>Issue</th>
+                    <th>State</th>
+                    <th>Session</th>
+                    <th>Blocked at</th>
+                    <th>Last update</th>
+                    <th>Error</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr :for={entry <- @payload.blocked}>
+                    <td>
+                      <div class="issue-stack">
+                        <span class="issue-id"><%= entry.issue_identifier %></span>
+                        <a class="issue-link" href={"/api/v1/#{entry.issue_identifier}"}>JSON details</a>
+                      </div>
+                    </td>
+                    <td>
+                      <span class={state_badge_class(entry.state || "Blocked")}>
+                        <%= entry.state || "Blocked" %>
+                      </span>
+                    </td>
+                    <td>
+                      <%= if entry.session_id do %>
+                        <button
+                          type="button"
+                          class="subtle-button"
+                          data-label="Copy ID"
+                          data-copy={entry.session_id}
+                          onclick="navigator.clipboard.writeText(this.dataset.copy); this.textContent = 'Copied'; clearTimeout(this._copyTimer); this._copyTimer = setTimeout(() => { this.textContent = this.dataset.label }, 1200);"
+                        >
+                          Copy ID
+                        </button>
+                      <% else %>
+                        <span class="muted">n/a</span>
+                      <% end %>
+                    </td>
+                    <td class="mono"><%= entry.blocked_at || "n/a" %></td>
+                    <td>
+                      <div class="detail-stack">
+                        <span
+                          class="event-text"
+                          title={entry.last_message || to_string(entry.last_event || "n/a")}
+                        ><%= entry.last_message || to_string(entry.last_event || "n/a") %></span>
+                        <span class="muted event-meta">
+                          <%= entry.last_event || "n/a" %>
+                          <%= if entry.last_event_at do %>
+                            · <span class="mono numeric"><%= entry.last_event_at %></span>
+                          <% end %>
+                        </span>
+                      </div>
+                    </td>
+                    <td><%= entry.error || "n/a" %></td>
                   </tr>
                 </tbody>
               </table>

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -15,10 +15,12 @@ defmodule SymphonyElixirWeb.Presenter do
           generated_at: generated_at,
           counts: %{
             running: length(snapshot.running),
-            retrying: length(snapshot.retrying)
+            retrying: length(snapshot.retrying),
+            blocked: length(Map.get(snapshot, :blocked, []))
           },
           running: Enum.map(snapshot.running, &running_entry_payload/1),
           retrying: Enum.map(snapshot.retrying, &retry_entry_payload/1),
+          blocked: Enum.map(Map.get(snapshot, :blocked, []), &blocked_entry_payload/1),
           codex_totals: snapshot.codex_totals,
           rate_limits: snapshot.rate_limits
         }
@@ -37,11 +39,12 @@ defmodule SymphonyElixirWeb.Presenter do
       %{} = snapshot ->
         running = Enum.find(snapshot.running, &(&1.identifier == issue_identifier))
         retry = Enum.find(snapshot.retrying, &(&1.identifier == issue_identifier))
+        blocked = Enum.find(Map.get(snapshot, :blocked, []), &(&1.identifier == issue_identifier))
 
-        if is_nil(running) and is_nil(retry) do
+        if is_nil(running) and is_nil(retry) and is_nil(blocked) do
           {:error, :issue_not_found}
         else
-          {:ok, issue_payload_body(issue_identifier, running, retry)}
+          {:ok, issue_payload_body(issue_identifier, running, retry, blocked)}
         end
 
       _ ->
@@ -60,14 +63,14 @@ defmodule SymphonyElixirWeb.Presenter do
     end
   end
 
-  defp issue_payload_body(issue_identifier, running, retry) do
+  defp issue_payload_body(issue_identifier, running, retry, blocked) do
     %{
       issue_identifier: issue_identifier,
-      issue_id: issue_id_from_entries(running, retry),
-      status: issue_status(running, retry),
+      issue_id: issue_id_from_entries(running, retry, blocked),
+      status: issue_status(running, retry, blocked),
       workspace: %{
-        path: workspace_path(issue_identifier, running, retry),
-        host: workspace_host(running, retry)
+        path: workspace_path(issue_identifier, running, retry, blocked),
+        host: workspace_host(running, retry, blocked)
       },
       attempts: %{
         restart_count: restart_count(retry),
@@ -75,25 +78,26 @@ defmodule SymphonyElixirWeb.Presenter do
       },
       running: running && running_issue_payload(running),
       retry: retry && retry_issue_payload(retry),
+      blocked: blocked && blocked_issue_payload(blocked),
       logs: %{
         codex_session_logs: []
       },
-      recent_events: (running && recent_events_payload(running)) || [],
-      last_error: retry && retry.error,
+      recent_events: recent_events_payload(running || blocked),
+      last_error: (blocked && blocked.error) || (retry && retry.error),
       tracked: %{}
     }
   end
 
-  defp issue_id_from_entries(running, retry),
-    do: (running && running.issue_id) || (retry && retry.issue_id)
+  defp issue_id_from_entries(running, retry, blocked),
+    do: (running && running.issue_id) || (retry && retry.issue_id) || (blocked && blocked.issue_id)
 
   defp restart_count(retry), do: max(retry_attempt(retry) - 1, 0)
   defp retry_attempt(nil), do: 0
   defp retry_attempt(retry), do: retry.attempt || 0
 
-  defp issue_status(_running, nil), do: "running"
-  defp issue_status(nil, _retry), do: "retrying"
-  defp issue_status(_running, _retry), do: "running"
+  defp issue_status(running, _retry, _blocked) when not is_nil(running), do: "running"
+  defp issue_status(nil, retry, _blocked) when not is_nil(retry), do: "retrying"
+  defp issue_status(nil, nil, _blocked), do: "blocked"
 
   defp running_entry_payload(entry) do
     %{
@@ -128,6 +132,22 @@ defmodule SymphonyElixirWeb.Presenter do
     }
   end
 
+  defp blocked_entry_payload(entry) do
+    %{
+      issue_id: entry.issue_id,
+      issue_identifier: entry.identifier,
+      state: entry.state,
+      error: entry.error,
+      worker_host: Map.get(entry, :worker_host),
+      workspace_path: Map.get(entry, :workspace_path),
+      session_id: entry.session_id,
+      blocked_at: iso8601(entry.blocked_at),
+      last_event: entry.last_codex_event,
+      last_message: summarize_message(entry.last_codex_message),
+      last_event_at: iso8601(entry.last_codex_timestamp)
+    }
+  end
+
   defp running_issue_payload(running) do
     %{
       worker_host: Map.get(running, :worker_host),
@@ -157,22 +177,41 @@ defmodule SymphonyElixirWeb.Presenter do
     }
   end
 
-  defp workspace_path(issue_identifier, running, retry) do
+  defp blocked_issue_payload(blocked) do
+    %{
+      worker_host: Map.get(blocked, :worker_host),
+      workspace_path: Map.get(blocked, :workspace_path),
+      session_id: blocked.session_id,
+      state: blocked.state,
+      error: blocked.error,
+      blocked_at: iso8601(blocked.blocked_at),
+      last_event: blocked.last_codex_event,
+      last_message: summarize_message(blocked.last_codex_message),
+      last_event_at: iso8601(blocked.last_codex_timestamp)
+    }
+  end
+
+  defp workspace_path(issue_identifier, running, retry, blocked) do
     (running && Map.get(running, :workspace_path)) ||
       (retry && Map.get(retry, :workspace_path)) ||
+      (blocked && Map.get(blocked, :workspace_path)) ||
       Path.join(Config.settings!().workspace.root, issue_identifier)
   end
 
-  defp workspace_host(running, retry) do
-    (running && Map.get(running, :worker_host)) || (retry && Map.get(retry, :worker_host))
+  defp workspace_host(running, retry, blocked) do
+    (running && Map.get(running, :worker_host)) ||
+      (retry && Map.get(retry, :worker_host)) ||
+      (blocked && Map.get(blocked, :worker_host))
   end
 
-  defp recent_events_payload(running) do
+  defp recent_events_payload(nil), do: []
+
+  defp recent_events_payload(entry) do
     [
       %{
-        at: iso8601(running.last_codex_timestamp),
-        event: running.last_codex_event,
-        message: summarize_message(running.last_codex_message)
+        at: iso8601(entry.last_codex_timestamp),
+        event: entry.last_codex_event,
+        message: summarize_message(entry.last_codex_message)
       }
     ]
     |> Enum.reject(&is_nil(&1.at))

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -262,6 +262,71 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server treats MCP elicitation requests as hard input blockers" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-mcp-elicitation-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-188")
+      codex_binary = Path.join(test_root, "fake-codex")
+      File.mkdir_p!(workspace)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      count=0
+      while IFS= read -r _line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-188"}}}'
+            ;;
+          3)
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-188"}}}'
+            ;;
+          4)
+            printf '%s\\n' '{"method":"mcpServer/elicitation/request","params":{"message":"Need operator input"}}'
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-mcp-elicitation",
+        identifier: "MT-188",
+        title: "MCP elicitation",
+        description: "Cannot satisfy MCP input",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-188",
+        labels: ["backend"]
+      }
+
+      assert {:error, {:turn_input_required, payload}} =
+               AppServer.run(workspace, "Needs MCP input", issue)
+
+      assert payload["method"] == "mcpServer/elicitation/request"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server fails when command execution approval is required under safer defaults" do
     test_root =
       Path.join(

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -342,7 +342,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert state_payload == %{
              "generated_at" => state_payload["generated_at"],
-             "counts" => %{"running" => 1, "retrying" => 1},
+             "counts" => %{"running" => 1, "retrying" => 1, "blocked" => 0},
              "running" => [
                %{
                  "issue_id" => "issue-http",
@@ -370,6 +370,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "workspace_path" => nil
                }
              ],
+             "blocked" => [],
              "codex_totals" => %{
                "input_tokens" => 4,
                "output_tokens" => 8,
@@ -404,6 +405,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
              },
              "retry" => nil,
+             "blocked" => nil,
              "logs" => %{"codex_session_logs" => []},
              "recent_events" => [],
              "last_error" => nil,
@@ -641,7 +643,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     response = Req.get!("http://127.0.0.1:#{port}/api/v1/state")
     assert response.status == 200
-    assert response.body["counts"] == %{"running" => 1, "retrying" => 1}
+    assert response.body["counts"] == %{"running" => 1, "retrying" => 1, "blocked" => 0}
 
     dashboard_css = Req.get!("http://127.0.0.1:#{port}/dashboard.css")
     assert dashboard_css.status == 200

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -342,7 +342,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert state_payload == %{
              "generated_at" => state_payload["generated_at"],
-             "counts" => %{"running" => 1, "retrying" => 1, "blocked" => 0},
+             "counts" => %{"running" => 1, "retrying" => 1, "blocked" => 1},
              "running" => [
                %{
                  "issue_id" => "issue-http",
@@ -370,7 +370,21 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "workspace_path" => nil
                }
              ],
-             "blocked" => [],
+             "blocked" => [
+               %{
+                 "issue_id" => "issue-blocked",
+                 "issue_identifier" => "MT-BLOCKED",
+                 "state" => "In Progress",
+                 "error" => "codex turn requires operator input",
+                 "worker_host" => "dm-dev2",
+                 "workspace_path" => "/workspaces/MT-BLOCKED",
+                 "session_id" => "thread-blocked",
+                 "blocked_at" => state_payload["blocked"] |> List.first() |> Map.fetch!("blocked_at"),
+                 "last_event" => "turn_input_required",
+                 "last_message" => "turn blocked: waiting for user input",
+                 "last_event_at" => state_payload["blocked"] |> List.first() |> Map.fetch!("last_event_at")
+               }
+             ],
              "codex_totals" => %{
                "input_tokens" => 4,
                "output_tokens" => 8,
@@ -416,6 +430,18 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     assert %{"status" => "retrying", "retry" => %{"attempt" => 2, "error" => "boom"}} =
              json_response(conn, 200)
+
+    conn = get(build_conn(), "/api/v1/MT-BLOCKED")
+
+    assert %{
+             "status" => "blocked",
+             "last_error" => "codex turn requires operator input",
+             "blocked" => %{
+               "session_id" => "thread-blocked",
+               "state" => "In Progress",
+               "error" => "codex turn requires operator input"
+             }
+           } = json_response(conn, 200)
 
     conn = get(build_conn(), "/api/v1/MT-MISSING")
 
@@ -544,7 +570,9 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert html =~ "Operations Dashboard"
     assert html =~ "MT-HTTP"
     assert html =~ "MT-RETRY"
+    assert html =~ "MT-BLOCKED"
     assert html =~ "rendered"
+    assert html =~ "turn blocked: waiting for user input"
     assert html =~ "Runtime"
     assert html =~ "Live"
     assert html =~ "Offline"
@@ -643,7 +671,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     response = Req.get!("http://127.0.0.1:#{port}/api/v1/state")
     assert response.status == 200
-    assert response.body["counts"] == %{"running" => 1, "retrying" => 1, "blocked" => 0}
+    assert response.body["counts"] == %{"running" => 1, "retrying" => 1, "blocked" => 1}
 
     dashboard_css = Req.get!("http://127.0.0.1:#{port}/dashboard.css")
     assert dashboard_css.status == 200
@@ -711,6 +739,25 @@ defmodule SymphonyElixir.ExtensionsTest do
           attempt: 2,
           due_in_ms: 2_000,
           error: "boom"
+        }
+      ],
+      blocked: [
+        %{
+          issue_id: "issue-blocked",
+          identifier: "MT-BLOCKED",
+          state: "In Progress",
+          error: "codex turn requires operator input",
+          worker_host: "dm-dev2",
+          workspace_path: "/workspaces/MT-BLOCKED",
+          session_id: "thread-blocked",
+          blocked_at: DateTime.utc_now(),
+          last_codex_event: :turn_input_required,
+          last_codex_message: %{
+            event: :turn_input_required,
+            message: %{"method" => "turn/input_required"},
+            timestamp: DateTime.utc_now()
+          },
+          last_codex_timestamp: DateTime.utc_now()
         }
       ],
       codex_totals: %{input_tokens: 4, output_tokens: 8, total_tokens: 12, seconds_running: 42.5},

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -961,6 +961,129 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert remaining_ms <= 10_500
   end
 
+  test "orchestrator blocks stalled workers that are waiting on MCP elicitation" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: nil,
+      codex_stall_timeout_ms: 1_000
+    )
+
+    issue_id = "issue-mcp-elicitation-stall"
+    orchestrator_name = Module.concat(__MODULE__, :McpElicitationBlockOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    worker_pid =
+      spawn(fn ->
+        receive do
+          :done -> :ok
+        end
+      end)
+
+    stale_activity_at = DateTime.add(DateTime.utc_now(), -5, :second)
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: worker_pid,
+      ref: make_ref(),
+      identifier: "MT-MCP",
+      issue: %Issue{id: issue_id, identifier: "MT-MCP", state: "In Progress"},
+      worker_host: "dm-dev2",
+      workspace_path: "/workspaces/MT-MCP",
+      session_id: "thread-mcp-turn-mcp",
+      last_codex_message: %{
+        event: :notification,
+        message: %{"method" => "mcpServer/elicitation/request"},
+        timestamp: stale_activity_at
+      },
+      last_codex_timestamp: stale_activity_at,
+      last_codex_event: :notification,
+      started_at: stale_activity_at
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(pid, :tick)
+    Process.sleep(100)
+    state = :sys.get_state(pid)
+
+    refute Process.alive?(worker_pid)
+    refute Map.has_key?(state.running, issue_id)
+    refute Map.has_key?(state.retry_attempts, issue_id)
+    assert MapSet.member?(state.claimed, issue_id)
+
+    assert %{
+             identifier: "MT-MCP",
+             error: "codex MCP elicitation requires operator input",
+             worker_host: "dm-dev2",
+             workspace_path: "/workspaces/MT-MCP"
+           } = state.blocked[issue_id]
+
+    assert %{blocked: [%{identifier: "MT-MCP", error: "codex MCP elicitation requires operator input"}]} =
+             Orchestrator.snapshot(orchestrator_name, 1_000)
+  end
+
+  test "orchestrator blocks failed workers after app-server reports input required" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
+
+    issue_id = "issue-input-required"
+    orchestrator_name = Module.concat(__MODULE__, :InputRequiredBlockOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    ref = make_ref()
+    started_at = DateTime.utc_now()
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: ref,
+      identifier: "MT-INPUT",
+      issue: %Issue{id: issue_id, identifier: "MT-INPUT", state: "In Progress"},
+      session_id: "thread-input-turn-input",
+      last_codex_message: %{
+        event: :turn_input_required,
+        message: %{"method" => "mcpServer/elicitation/request"},
+        timestamp: started_at
+      },
+      last_codex_timestamp: started_at,
+      last_codex_event: :turn_input_required,
+      started_at: started_at
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(pid, {:DOWN, ref, :process, self(), {:shutdown, :input_required}})
+    Process.sleep(50)
+    state = :sys.get_state(pid)
+
+    refute Map.has_key?(state.running, issue_id)
+    refute Map.has_key?(state.retry_attempts, issue_id)
+    assert MapSet.member?(state.claimed, issue_id)
+
+    assert %{
+             identifier: "MT-INPUT",
+             error: "codex turn requires operator input"
+           } = state.blocked[issue_id]
+  end
+
   test "status dashboard renders offline marker to terminal" do
     rendered =
       ExUnit.CaptureIO.capture_io(fn ->

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1084,6 +1084,56 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            } = state.blocked[issue_id]
   end
 
+  test "orchestrator blocks normal worker exits after input required completion" do
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
+
+    issue_id = "issue-input-required-normal"
+    orchestrator_name = Module.concat(__MODULE__, :InputRequiredNormalBlockOrchestrator)
+    {:ok, pid} = Orchestrator.start_link(name: orchestrator_name)
+
+    on_exit(fn ->
+      if Process.alive?(pid) do
+        Process.exit(pid, :normal)
+      end
+    end)
+
+    ref = make_ref()
+    initial_state = :sys.get_state(pid)
+
+    running_entry = %{
+      pid: self(),
+      ref: ref,
+      identifier: "MT-INPUT-NORMAL",
+      issue: %Issue{id: issue_id, identifier: "MT-INPUT-NORMAL", state: "In Progress"},
+      session_id: "thread-input-normal",
+      completion: %{outcome: :input_required},
+      last_codex_message: nil,
+      last_codex_timestamp: nil,
+      last_codex_event: nil,
+      started_at: DateTime.utc_now()
+    }
+
+    :sys.replace_state(pid, fn _ ->
+      initial_state
+      |> Map.put(:running, %{issue_id => running_entry})
+      |> Map.put(:claimed, MapSet.put(initial_state.claimed, issue_id))
+    end)
+
+    send(pid, {:DOWN, ref, :process, self(), :normal})
+    Process.sleep(50)
+    state = :sys.get_state(pid)
+
+    refute Map.has_key?(state.running, issue_id)
+    refute Map.has_key?(state.retry_attempts, issue_id)
+    refute MapSet.member?(state.completed, issue_id)
+    assert MapSet.member?(state.claimed, issue_id)
+
+    assert %{
+             identifier: "MT-INPUT-NORMAL",
+             error: "codex turn requires operator input"
+           } = state.blocked[issue_id]
+  end
+
   test "status dashboard renders offline marker to terminal" do
     rendered =
       ExUnit.CaptureIO.capture_io(fn ->


### PR DESCRIPTION
#### Context

Codex app-server sessions can request operator input or MCP elicitation. These should pause visibly instead of retrying until exhausted.

#### TL;DR

*Show input-blocked Symphony sessions in state, API, and dashboard.*

#### Summary

- Treat Codex input-required and MCP elicitation events as blocked sessions.
- Keep blocked issues claimed until Linear state/routing changes.
- Add blocked counts and per-issue blocked details to presenter payloads.
- Render blocked sessions in the dashboard.
- Add regression coverage for app-server and orchestrator blocked flows.

#### Alternatives

- Retrying was rejected because human-input blockers are not transient failures.
- Moving Linear to Done was rejected because Done is post-merge terminal state.

#### Test Plan

- [ ] `make -C elixir all`
- [x] `mise exec -- mix format`
- [x] `mise exec -- mix test test/symphony_elixir/app_server_test.exs test/symphony_elixir/extensions_test.exs test/symphony_elixir/orchestrator_status_test.exs`
