### PR TITLE
[codex] Harden PR description lint workflow

### DIFF
--- a/.github/workflows/pr-description-lint.yml
+++ b/.github/workflows/pr-description-lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr-description:
     runs-on: ubuntu-latest
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up mise tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3


### PR DESCRIPTION
#### Context

Restrict the PR description lint workflow so forked PR checks run with the least token access needed.

#### TL;DR

*Set read-only workflow permissions and stop checkout from storing credentials.*

#### Summary

- Add explicit contents read permission to the PR description lint workflow.
- Set checkout persist-credentials to false for the lint job.

#### Alternatives

- Leave defaults unchanged, but explicit permissions make the token scope easier to review.

#### Test Plan

- [ ] `make -C elixir all`
- [x] Parsed `.github/workflows/pr-description-lint.yml` with PyYAML.
