### PR TITLE
docs: add SD-4 Symphony smoke-test note

### DIFF
--- a/docs/symphony-smoke-test-one.md
+++ b/docs/symphony-smoke-test-one.md
@@ -1,0 +1,3 @@
+# Symphony Smoke Test
+
+Symphony picked up Jira issue SD-4 and handled it by adding this isolated smoke-test doc.


### PR DESCRIPTION
#### Context

Smoke-test ticket SD-4 asks for an isolated doc proving Symphony picked up and handled the issue.

#### TL;DR

*Adds the SD-4 Symphony smoke-test note.*

#### Summary

- Adds `docs/symphony-smoke-test-one.md`.
- Keeps the change docs-only and limited to the smoke-test note.
- Mentions Jira issue key `SD-4`.

#### Alternatives

- Leave no repo artifact; rejected because the ticket asks for a committed smoke-test doc.

#### Test Plan

- [x] `make -C elixir all` via GitHub Actions `make-all`
- [x] `test -f docs/symphony-smoke-test-one.md && rg "SD-4|Symphony" docs/symphony-smoke-test-one.md && git diff --check`
- [x] `mix pr_body.check --file <process-substitution>`