### PR TITLE
docs: add second Symphony smoke test note

### DIFF
--- a/docs/symphony-smoke-test-two.md
+++ b/docs/symphony-smoke-test-two.md
@@ -1,0 +1,3 @@
+# Symphony Smoke Test Two
+
+SD-5 was picked up and handled by Symphony as a separate smoke-test Jira issue.


### PR DESCRIPTION
#### Context

SD-5 needs a minimal document confirming Symphony handled this separate smoke-test Jira issue.

#### TL;DR

*Adds the second Symphony smoke-test confirmation doc.*

#### Summary

- Adds docs/symphony-smoke-test-two.md.
- Mentions SD-5 and Symphony in the note.

#### Alternatives

- Kept the change docs-only to match the smoke-test scope.

#### Test Plan

- [x] `test -f docs/symphony-smoke-test-two.md`
- [x] `rg "SD-5|Symphony" docs/symphony-smoke-test-two.md`
- [x] `git diff --check`
- [x] `make -C elixir fmt-check`
- [x] `mix pr_body.check --file <process-substitution>`
- [x] `make -C elixir all` via GitHub `make-all` check; local sandbox blocked Hex network/cache access
- [x] GitHub `validate-pr-description` check
