### PR TITLE
Add daemon polling smoke-test note

### DIFF
--- a/docs/symphony-smoke-daemon-polling.md
+++ b/docs/symphony-smoke-daemon-polling.md
@@ -1,0 +1,3 @@
+# Symphony Smoke Test
+
+This note verifies the Symphony daemon polling workflow can detect a small markdown smoke-test change.


### PR DESCRIPTION
#### Context

SD-8 asks for one isolated markdown file to smoke-test Symphony daemon polling.

#### TL;DR

*Adds a small daemon polling smoke-test note.*

#### Summary

- Adds `docs/symphony-smoke-daemon-polling.md`.
- Keeps the change docs-only with no source behavior changes.

#### Alternatives

- Did not edit existing docs so the smoke-test change stays isolated.

#### Test Plan

- [x] `git status --short`
- [x] `mix pr_body.check --file <PR body>`
- [x] GitHub Actions `make-all`
- Local `make -C elixir all`: blocked in sandbox by policy denial for repo.hex.pm; CI `make-all` passed.