### PR TITLE
docs: add board review smoke test note

### DIFF
--- a/docs/symphony-smoke-board-review.md
+++ b/docs/symphony-smoke-board-review.md
@@ -1,0 +1,3 @@
+# Symphony Board Review Smoke Test
+
+This brief note confirms this is a Symphony smoke test for the board review workflow.


### PR DESCRIPTION
#### Context

Adds the requested SD-6 smoke-test note so the Symphony board review workflow can validate a minimal docs-only change.

#### TL;DR

*Add a short board review smoke-test markdown note.*

#### Summary

- Added docs/symphony-smoke-board-review.md with a short heading and note.
- Kept the change isolated to one new docs file.

#### Alternatives

- No code or app behavior changes were made because the ticket scope is docs-only.

#### Test Plan

- [x] `make -C elixir all` via GitHub Actions `make-all` rerun
- [x] `mix pr_body.check --file <(gh pr view 79 --repo openai/symphony --json body -q .body)`
- [x] `git status --short` shows only `?? docs/symphony-smoke-board-review.md`