### PR TITLE
docs: add SD-9 board automation check

### DIFF
--- a/docs/symphony-board-automation-check.md
+++ b/docs/symphony-board-automation-check.md
@@ -1,0 +1,6 @@
+# Symphony Board Automation Check
+
+Symphony picked up Jira issue SD-9 and handled it by adding this isolated sample ticket artifact.
+
+This document mirrors the prior smoke-test pattern so board automation can verify a ticket-driven
+repository change path.


### PR DESCRIPTION
#### Context

SD-9 is a sample Jira board automation check and needs an isolated repo artifact for the ticket-driven path.

#### TL;DR

*Add an SD-9 board automation check note.*

#### Summary

- Add `docs/symphony-board-automation-check.md`.
- Mirror the existing smoke-test docs pattern for SD-9.

#### Alternatives

- No repo change; rejected because the ticket needs a repository artifact for automation proof.

#### Test Plan

- [x] `make -C elixir build`
- [x] `make -C elixir fmt-check`
- [x] `make -C elixir lint`
- [x] `make -C elixir coverage`
- [x] `mix dialyzer --format short`
- [ ] `make -C elixir all` blocked by sandbox policy on `https://repo.hex.pm` during `mix deps.get`.
