### PR TITLE
Fix live E2E worker isolation and SSH paths

### DIFF
--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -403,7 +403,7 @@ defmodule SymphonyElixir.Workspace do
       "#{variable_name}=#{shell_escape(raw_path)}",
       "case \"$#{variable_name}\" in",
       "  '~') #{variable_name}=\"$HOME\" ;;",
-      "  '~/'*) " <> variable_name <> "=\"$HOME/${" <> variable_name <> "#~/}\" ;;",
+      "  '~/'*) " <> variable_name <> "=\"$HOME/${" <> variable_name <> "#\\~/}\" ;;",
       "esac"
     ]
     |> Enum.join("\n")

--- a/elixir/test/symphony_elixir/live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/live_e2e_test.exs
@@ -8,7 +8,6 @@ defmodule SymphonyElixir.LiveE2ETest do
   @moduletag timeout: 300_000
 
   @default_team_key "SYME2E"
-  @default_docker_auth_json Path.join(System.user_home!(), ".codex/auth.json")
   @docker_worker_count 2
   @docker_support_dir Path.expand("../support/live_e2e_docker", __DIR__)
   @docker_compose_file Path.join(@docker_support_dir, "docker-compose.yml")
@@ -475,41 +474,45 @@ defmodule SymphonyElixir.LiveE2ETest do
           "Symphony Live E2E #{backend} #{System.unique_integer([:positive])}"
         )
 
-      issue =
-        create_issue!(
-          team["id"],
-          project["id"],
-          active_state["id"],
-          "Symphony live e2e #{backend} issue for #{project["name"]}"
+      try do
+        issue =
+          create_issue!(
+            team["id"],
+            project["id"],
+            active_state["id"],
+            "Symphony live e2e #{backend} issue for #{project["name"]}"
+          )
+
+        write_workflow_file!(workflow_file,
+          tracker_api_token: "$LINEAR_API_KEY",
+          tracker_project_slug: project["slugId"],
+          tracker_active_states: active_state_names(team),
+          tracker_terminal_states: terminal_states,
+          workspace_root: worker_setup.workspace_root,
+          worker_ssh_hosts: worker_setup.ssh_worker_hosts,
+          codex_command: worker_setup.codex_command,
+          codex_approval_policy: "never",
+          codex_turn_sandbox_policy: Map.get(worker_setup, :codex_turn_sandbox_policy),
+          codex_read_timeout_ms: 60_000,
+          codex_turn_timeout_ms: 600_000,
+          codex_stall_timeout_ms: 600_000,
+          observability_enabled: false,
+          prompt: live_prompt(project["slugId"])
         )
 
-      write_workflow_file!(workflow_file,
-        tracker_api_token: "$LINEAR_API_KEY",
-        tracker_project_slug: project["slugId"],
-        tracker_active_states: active_state_names(team),
-        tracker_terminal_states: terminal_states,
-        workspace_root: worker_setup.workspace_root,
-        worker_ssh_hosts: worker_setup.ssh_worker_hosts,
-        codex_command: worker_setup.codex_command,
-        codex_approval_policy: "never",
-        codex_turn_timeout_ms: 600_000,
-        codex_stall_timeout_ms: 600_000,
-        observability_enabled: false,
-        prompt: live_prompt(project["slugId"])
-      )
+        assert :ok = AgentRunner.run(issue, self(), max_turns: 3)
 
-      assert :ok = AgentRunner.run(issue, self(), max_turns: 3)
+        runtime_info = receive_runtime_info!(issue.id)
 
-      runtime_info = receive_runtime_info!(issue.id)
+        assert read_worker_result!(runtime_info, @result_file) ==
+                 expected_result(issue.identifier, project["slugId"])
 
-      assert read_worker_result!(runtime_info, @result_file) ==
-               expected_result(issue.identifier, project["slugId"])
-
-      issue_snapshot = fetch_issue_details!(issue.id)
-      assert issue_completed?(issue_snapshot)
-      assert issue_has_comment?(issue_snapshot, expected_comment(issue.identifier, project["slugId"]))
-
-      assert :ok = complete_project(project["id"], completed_project_status["id"])
+        issue_snapshot = fetch_issue_details!(issue.id)
+        assert issue_completed?(issue_snapshot)
+        assert issue_has_comment?(issue_snapshot, expected_comment(issue.identifier, project["slugId"]))
+      after
+        assert :ok = complete_project(project["id"], completed_project_status["id"])
+      end
     after
       restart_orchestrator_if_needed()
       cleanup_live_worker_setup(worker_setup)
@@ -519,9 +522,11 @@ defmodule SymphonyElixir.LiveE2ETest do
   end
 
   defp live_worker_setup!(:local, _run_id, test_root) when is_binary(test_root) do
+    codex_home = isolated_codex_home!(test_root)
+
     %{
       cleanup: fn -> :ok end,
-      codex_command: "codex app-server",
+      codex_command: "env CODEX_HOME=#{shell_escape(codex_home)} codex app-server",
       ssh_worker_hosts: [],
       workspace_root: Path.join(test_root, "workspaces")
     }
@@ -534,6 +539,28 @@ defmodule SymphonyElixir.LiveE2ETest do
 
       _hosts ->
         live_ssh_worker_setup!(run_id)
+    end
+  end
+
+  defp isolated_codex_home!(test_root) when is_binary(test_root) do
+    codex_home = Path.join(test_root, "codex-home")
+    auth_json_path = Path.join(codex_home, "auth.json")
+
+    File.mkdir_p!(codex_home)
+    File.cp!(source_codex_auth_json!(), auth_json_path)
+    File.chmod!(auth_json_path, 0o600)
+
+    codex_home
+  end
+
+  defp source_codex_auth_json! do
+    codex_home = System.get_env("CODEX_HOME") || Path.join(System.user_home!(), ".codex")
+    auth_json_path = Path.join(codex_home, "auth.json")
+
+    if File.regular?(auth_json_path) do
+      auth_json_path
+    else
+      flunk("live e2e requires Codex auth at #{auth_json_path}")
     end
   end
 
@@ -569,7 +596,7 @@ defmodule SymphonyElixir.LiveE2ETest do
     ssh_root = Path.join(test_root, "live-docker-ssh")
     key_path = Path.join(ssh_root, "id_ed25519")
     config_path = Path.join(ssh_root, "config")
-    auth_json_path = @default_docker_auth_json
+    auth_json_path = source_codex_auth_json!()
     worker_ports = reserve_tcp_ports(@docker_worker_count)
     worker_hosts = Enum.map(worker_ports, &"localhost:#{&1}")
     project_name = docker_project_name(run_id)
@@ -598,6 +625,7 @@ defmodule SymphonyElixir.LiveE2ETest do
             base_cleanup.()
           end,
           codex_command: "codex app-server",
+          codex_turn_sandbox_policy: %{type: "dangerFullAccess"},
           ssh_worker_hosts: worker_hosts,
           workspace_root: remote_workspace_root
         }

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -1358,7 +1358,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       assert trace =~ "-p 2200 worker-01 bash -lc"
       assert trace =~ "__SYMPHONY_WORKSPACE__"
       assert trace =~ "~/.symphony-remote-workspaces/MT-SSH-WS"
-      assert trace =~ "${workspace#~/}"
+      assert trace =~ "${workspace#\\~/}"
       assert trace =~ "echo before-run"
       assert trace =~ "echo after-run"
       assert trace =~ "echo before-remove"


### PR DESCRIPTION
#### Context

Live E2E could fail on cold Codex startup, remote `~/` workspace expansion, or Docker nested sandboxing.

#### TL;DR

*Make local and SSH live smoke tests reliable with test-only Codex isolation.*

#### Summary

- Fix remote `~/` workspace expansion so SSH workers use the intended home path.
- Run local live tests with an auth-only temporary `CODEX_HOME` and a 60s startup timeout.
- Use full access only inside disposable Docker SSH workers and finalize projects on failures.

#### Alternatives

- Did not change production Codex timeout defaults; the 60s budget is test-only.
- Did not make Docker privileged; the container remains the isolation boundary.

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && CODEX_HOME=<temporary auth-only home> make e2e`
