### PR TITLE
Preserve last good config on typed-invalid reloads

### DIFF
--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -4,7 +4,7 @@ defmodule SymphonyElixir.Config do
   """
 
   alias SymphonyElixir.Config.Schema
-  alias SymphonyElixir.Workflow
+  alias SymphonyElixir.{Workflow, WorkflowStore}
 
   @default_prompt_template """
   You are working on a Linear issue.
@@ -28,13 +28,7 @@ defmodule SymphonyElixir.Config do
 
   @spec settings() :: {:ok, Schema.t()} | {:error, term()}
   def settings do
-    case Workflow.current() do
-      {:ok, %{config: config}} when is_map(config) ->
-        Schema.parse(config)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
+    WorkflowStore.settings()
   end
 
   @spec settings!() :: Schema.t()
@@ -93,7 +87,8 @@ defmodule SymphonyElixir.Config do
 
   @spec validate!() :: :ok | {:error, term()}
   def validate! do
-    with {:ok, settings} <- settings() do
+    with :ok <- WorkflowStore.force_reload(),
+         {:ok, settings} <- settings() do
       validate_semantics(settings)
     end
   end

--- a/elixir/lib/symphony_elixir/workflow_store.ex
+++ b/elixir/lib/symphony_elixir/workflow_store.ex
@@ -6,6 +6,7 @@ defmodule SymphonyElixir.WorkflowStore do
   use GenServer
   require Logger
 
+  alias SymphonyElixir.Config.Schema
   alias SymphonyElixir.Workflow
 
   @poll_interval_ms 1_000
@@ -13,7 +14,7 @@ defmodule SymphonyElixir.WorkflowStore do
   defmodule State do
     @moduledoc false
 
-    defstruct [:path, :stamp, :workflow]
+    defstruct [:path, :stamp, :workflow, :settings]
   end
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -32,6 +33,20 @@ defmodule SymphonyElixir.WorkflowStore do
     end
   end
 
+  @spec settings() :: {:ok, Schema.t()} | {:error, term()}
+  def settings do
+    case Process.whereis(__MODULE__) do
+      pid when is_pid(pid) ->
+        GenServer.call(__MODULE__, :settings)
+
+      _ ->
+        case load_state(Workflow.workflow_file_path()) do
+          {:ok, %State{settings: settings}} -> {:ok, settings}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
   @spec force_reload() :: :ok | {:error, term()}
   def force_reload do
     case Process.whereis(__MODULE__) do
@@ -39,8 +54,8 @@ defmodule SymphonyElixir.WorkflowStore do
         GenServer.call(__MODULE__, :force_reload)
 
       _ ->
-        case Workflow.load() do
-          {:ok, _workflow} -> :ok
+        case load_state(Workflow.workflow_file_path()) do
+          {:ok, _state} -> :ok
           {:error, reason} -> {:error, reason}
         end
     end
@@ -76,6 +91,16 @@ defmodule SymphonyElixir.WorkflowStore do
 
       {:error, reason, new_state} ->
         {:reply, {:error, reason}, new_state}
+    end
+  end
+
+  def handle_call(:settings, _from, %State{} = state) do
+    case reload_state(state) do
+      {:ok, new_state} ->
+        {:reply, {:ok, new_state.settings}, new_state}
+
+      {:error, _reason, new_state} ->
+        {:reply, {:ok, new_state.settings}, new_state}
     end
   end
 
@@ -130,8 +155,9 @@ defmodule SymphonyElixir.WorkflowStore do
 
   defp load_state(path) do
     with {:ok, workflow} <- Workflow.load(path),
+         {:ok, settings} <- Schema.parse(workflow.config),
          {:ok, stamp} <- current_stamp(path) do
-      {:ok, %State{path: path, stamp: stamp, workflow: workflow}}
+      {:ok, %State{path: path, stamp: stamp, workflow: workflow, settings: settings}}
     else
       {:error, reason} ->
         {:error, reason}

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -20,10 +20,6 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), poll_interval_ms: "invalid")
 
-    assert_raise ArgumentError, ~r/interval_ms/, fn ->
-      Config.settings!().polling.interval_ms
-    end
-
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
     assert message =~ "polling.interval_ms"
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -105,16 +105,34 @@ defmodule SymphonyElixir.ExtensionsTest do
     ensure_workflow_store_running()
     assert {:ok, %{prompt: "You are an agent for this repository."}} = Workflow.current()
 
-    write_workflow_file!(Workflow.workflow_file_path(), prompt: "Second prompt")
+    write_workflow_file!(Workflow.workflow_file_path(),
+      prompt: "Second prompt",
+      poll_interval_ms: 45_000
+    )
+
     send(WorkflowStore, :poll)
 
     assert_eventually(fn ->
       match?({:ok, %{prompt: "Second prompt"}}, Workflow.current())
     end)
 
+    good_settings = Config.settings!()
+    assert good_settings.polling.interval_ms == 45_000
+
     File.write!(Workflow.workflow_file_path(), "---\ntracker: [\n---\nBroken prompt\n")
     assert {:error, _reason} = WorkflowStore.force_reload()
     assert {:ok, %{prompt: "Second prompt"}} = Workflow.current()
+
+    File.write!(
+      Workflow.workflow_file_path(),
+      "---\npolling:\n  interval_ms: nope\n---\nTyped-invalid prompt\n"
+    )
+
+    assert {:error, {:invalid_workflow_config, message}} = WorkflowStore.force_reload()
+    assert message =~ "polling.interval_ms"
+    assert {:ok, %{prompt: "Second prompt"}} = Workflow.current()
+    assert Config.settings!().polling.interval_ms == good_settings.polling.interval_ms
+    assert {:error, {:invalid_workflow_config, _message}} = Config.validate!()
 
     third_workflow = Path.join(Path.dirname(Workflow.workflow_file_path()), "THIRD_WORKFLOW.md")
     write_workflow_file!(third_workflow, prompt: "Third prompt")
@@ -143,6 +161,9 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, WorkflowStore)
 
     Workflow.set_workflow_file_path(missing_path)
+
+    assert {:error, {:missing_workflow_file, ^missing_path, :enoent}} =
+             WorkflowStore.settings()
 
     assert {:error, {:missing_workflow_file, ^missing_path, :enoent}} =
              WorkflowStore.force_reload()


### PR DESCRIPTION
#### Context

A YAML-valid, typed-invalid reload replaced cached config and prompt, then made `Config.settings!` raise.

#### TL;DR

*Keep the last good typed workflow when a reload cannot be parsed.*

#### Summary

- Cache parsed settings with each workflow store state.
- Reject typed-invalid reloads before config and prompt become current.
- Keep preflight errors visible while runtime getters use last known good values.

#### Alternatives

- Did not fold semantic tracker preflight into store admission; that is a separate finding.
- Did not add orchestrator rescue logic; invalid typed state no longer reaches `settings!`.

#### Test Plan

- [x] `mix test test/symphony_elixir/extensions_test.exs:104`
- [x] `mix test --cover --seed 659305`
- [x] `make -C elixir all`
