### PR TITLE
Validate workflow before scheduling

### DIFF
--- a/elixir/config/config.exs
+++ b/elixir/config/config.exs
@@ -14,3 +14,8 @@ config :symphony_elixir, SymphonyElixirWeb.Endpoint,
   secret_key_base: String.duplicate("s", 64),
   check_origin: false,
   server: false
+
+if config_env() == :test do
+  config :symphony_elixir,
+    workflow_file_path: Path.expand("../test/fixtures/startup_workflow.md", __DIR__)
+end

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -87,10 +87,7 @@ defmodule SymphonyElixir.Config do
 
   @spec validate!() :: :ok | {:error, term()}
   def validate! do
-    with :ok <- WorkflowStore.force_reload(),
-         {:ok, settings} <- settings() do
-      validate_semantics(settings)
-    end
+    WorkflowStore.force_reload()
   end
 
   @spec codex_runtime_settings(Path.t() | nil, keyword()) ::
@@ -109,7 +106,9 @@ defmodule SymphonyElixir.Config do
     end
   end
 
-  defp validate_semantics(settings) do
+  @doc false
+  @spec validate_settings(Schema.t()) :: :ok | {:error, term()}
+  def validate_settings(settings) do
     cond do
       is_nil(settings.tracker.kind) ->
         {:error, :missing_tracker_kind}
@@ -117,16 +116,19 @@ defmodule SymphonyElixir.Config do
       settings.tracker.kind not in ["linear", "memory"] ->
         {:error, {:unsupported_tracker_kind, settings.tracker.kind}}
 
-      settings.tracker.kind == "linear" and not is_binary(settings.tracker.api_key) ->
+      settings.tracker.kind == "linear" and not present_string?(settings.tracker.api_key) ->
         {:error, :missing_linear_api_token}
 
-      settings.tracker.kind == "linear" and not is_binary(settings.tracker.project_slug) ->
+      settings.tracker.kind == "linear" and not present_string?(settings.tracker.project_slug) ->
         {:error, :missing_linear_project_slug}
 
       true ->
         :ok
     end
   end
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
 
   defp format_config_error(reason) do
     case reason do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -199,6 +199,13 @@ defmodule SymphonyElixir.Config.Schema do
         empty_values: []
       )
       |> validate_required([:command])
+      |> validate_change(:command, fn :command, command ->
+        if command != "" and String.trim(command) == "" do
+          [command: "can't be blank"]
+        else
+          []
+        end
+      end)
       |> validate_number(:turn_timeout_ms, greater_than: 0)
       |> validate_number(:read_timeout_ms, greater_than: 0)
       |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -53,25 +53,30 @@ defmodule SymphonyElixir.Orchestrator do
 
   @impl true
   def init(opts) do
-    now_ms = System.monotonic_time(:millisecond)
-    config = Config.settings!()
+    case Config.settings() do
+      {:ok, config} ->
+        now_ms = System.monotonic_time(:millisecond)
 
-    state = %State{
-      poll_interval_ms: config.polling.interval_ms,
-      max_concurrent_agents: config.agent.max_concurrent_agents,
-      next_poll_due_at_ms: now_ms,
-      poll_check_in_progress: false,
-      tick_timer_ref: nil,
-      tick_token: nil,
-      task_supervisor: Keyword.get(opts, :task_supervisor, SymphonyElixir.TaskSupervisor),
-      codex_totals: @empty_codex_totals,
-      codex_rate_limits: nil
-    }
+        state = %State{
+          poll_interval_ms: config.polling.interval_ms,
+          max_concurrent_agents: config.agent.max_concurrent_agents,
+          next_poll_due_at_ms: now_ms,
+          poll_check_in_progress: false,
+          tick_timer_ref: nil,
+          tick_token: nil,
+          task_supervisor: Keyword.get(opts, :task_supervisor, SymphonyElixir.TaskSupervisor),
+          codex_totals: @empty_codex_totals,
+          codex_rate_limits: nil
+        }
 
-    run_terminal_workspace_cleanup()
-    state = schedule_tick(state, 0)
+        run_terminal_workspace_cleanup()
+        state = schedule_tick(state, 0)
 
-    {:ok, state}
+        {:ok, state}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
   end
 
   @impl true

--- a/elixir/lib/symphony_elixir/workflow_store.ex
+++ b/elixir/lib/symphony_elixir/workflow_store.ex
@@ -6,6 +6,7 @@ defmodule SymphonyElixir.WorkflowStore do
   use GenServer
   require Logger
 
+  alias SymphonyElixir.Config
   alias SymphonyElixir.Config.Schema
   alias SymphonyElixir.Workflow
 
@@ -156,6 +157,7 @@ defmodule SymphonyElixir.WorkflowStore do
   defp load_state(path) do
     with {:ok, workflow} <- Workflow.load(path),
          {:ok, settings} <- Schema.parse(workflow.config),
+         :ok <- Config.validate_settings(settings),
          {:ok, stamp} <- current_stamp(path) do
       {:ok, %State{path: path, stamp: stamp, workflow: workflow, settings: settings}}
     else

--- a/elixir/test/fixtures/startup_workflow.md
+++ b/elixir/test/fixtures/startup_workflow.md
@@ -1,0 +1,8 @@
+---
+tracker:
+  kind: memory
+codex:
+  command: codex app-server
+---
+
+Test workflow.

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -3,6 +3,7 @@ defmodule SymphonyElixir.CoreTest do
 
   test "config defaults and validation checks" do
     write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
       tracker_api_token: nil,
       tracker_project_slug: nil,
       poll_interval_ms: nil,
@@ -45,6 +46,20 @@ defmodule SymphonyElixir.CoreTest do
     assert {:error, :missing_linear_project_slug} = Config.validate!()
 
     write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "   ",
+      tracker_project_slug: "project"
+    )
+
+    assert {:error, :missing_linear_api_token} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "token",
+      tracker_project_slug: ""
+    )
+
+    assert {:error, :missing_linear_project_slug} = Config.validate!()
+
+    write_workflow_file!(Workflow.workflow_file_path(),
       tracker_project_slug: "project",
       codex_command: ""
     )
@@ -54,8 +69,9 @@ defmodule SymphonyElixir.CoreTest do
     assert message =~ "can't be blank"
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "   ")
-    assert :ok = Config.validate!()
-    assert Config.settings!().codex.command == "   "
+    assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
+    assert message =~ "codex.command"
+    assert message =~ "can't be blank"
 
     write_workflow_file!(Workflow.workflow_file_path(), codex_command: "/bin/sh app-server")
     assert :ok = Config.validate!()
@@ -86,7 +102,12 @@ defmodule SymphonyElixir.CoreTest do
 
   test "current WORKFLOW.md file is valid and complete" do
     original_workflow_path = Workflow.workflow_file_path()
+    previous_linear_api_key = System.get_env("LINEAR_API_KEY")
+
     on_exit(fn -> Workflow.set_workflow_file_path(original_workflow_path) end)
+    on_exit(fn -> restore_env("LINEAR_API_KEY", previous_linear_api_key) end)
+
+    System.put_env("LINEAR_API_KEY", "test-linear-api-key")
     Workflow.clear_workflow_file_path()
 
     assert {:ok, %{config: config, prompt: prompt}} = Workflow.load()
@@ -223,6 +244,108 @@ defmodule SymphonyElixir.CoreTest do
     assert is_pid(Process.whereis(SymphonyElixir.Orchestrator))
 
     GenServer.stop(pid)
+  end
+
+  test "orchestrator fails startup when semantic preflight fails" do
+    issue_suffix = System.unique_integer([:positive])
+    orchestrator_name = Module.concat(__MODULE__, "InvalidOrchestrator#{issue_suffix}")
+    workflow_path = Workflow.workflow_file_path()
+
+    on_exit(fn ->
+      if pid = Process.whereis(orchestrator_name) do
+        GenServer.stop(pid)
+      end
+
+      write_workflow_file!(workflow_path, tracker_kind: "memory")
+
+      if is_nil(Process.whereis(WorkflowStore)) do
+        assert {:ok, _pid} = Supervisor.restart_child(SymphonyElixir.Supervisor, WorkflowStore)
+      end
+
+      if is_nil(Process.whereis(SymphonyElixir.AgentRuntimeSupervisor)) do
+        assert {:ok, _pid} =
+                 Supervisor.restart_child(
+                   SymphonyElixir.Supervisor,
+                   SymphonyElixir.AgentRuntimeSupervisor
+                 )
+      end
+    end)
+
+    assert :ok =
+             Supervisor.terminate_child(
+               SymphonyElixir.Supervisor,
+               SymphonyElixir.AgentRuntimeSupervisor
+             )
+
+    assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, WorkflowStore)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_api_token: "token",
+      tracker_project_slug: nil
+    )
+
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    assert {:error, :missing_linear_project_slug} =
+             Orchestrator.start_link(name: orchestrator_name)
+
+    Process.flag(:trap_exit, previous_trap_exit)
+
+    refute Process.whereis(orchestrator_name)
+  end
+
+  test "runtime restart keeps last good settings after an invalid reload" do
+    issue_suffix = System.unique_integer([:positive])
+    runtime_supervisor_name = Module.concat(__MODULE__, "ReloadRuntime#{issue_suffix}")
+    task_supervisor_name = Module.concat(__MODULE__, "ReloadTaskSupervisor#{issue_suffix}")
+    orchestrator_name = Module.concat(__MODULE__, "ReloadOrchestrator#{issue_suffix}")
+
+    on_exit(fn ->
+      if pid = Process.whereis(runtime_supervisor_name) do
+        GenServer.stop(pid)
+      end
+    end)
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+
+    assert {:ok, runtime_pid} =
+             SymphonyElixir.AgentRuntimeSupervisor.start_link(
+               name: runtime_supervisor_name,
+               task_supervisor_name: task_supervisor_name,
+               orchestrator_name: orchestrator_name
+             )
+
+    Process.unlink(runtime_pid)
+    original_orchestrator_pid = Process.whereis(orchestrator_name)
+
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "linear",
+      tracker_api_token: "token",
+      tracker_project_slug: nil
+    )
+
+    assert {:error, :missing_linear_project_slug} = Config.validate!()
+    assert Config.settings!().tracker.kind == "memory"
+
+    Process.exit(original_orchestrator_pid, :kill)
+
+    restarted_orchestrator_pid =
+      eventually_value(fn ->
+        case Process.whereis(orchestrator_name) do
+          pid when is_pid(pid) and pid != original_orchestrator_pid ->
+            case Orchestrator.snapshot(orchestrator_name, 100) do
+              %{} -> pid
+              _ -> nil
+            end
+
+          _ ->
+            nil
+        end
+      end)
+
+    assert is_pid(restarted_orchestrator_pid)
+    assert Process.whereis(orchestrator_name) == restarted_orchestrator_pid
+    assert Process.alive?(runtime_pid)
   end
 
   test "restarting the orchestrator does not overlap redispatched work" do
@@ -1228,6 +1351,11 @@ defmodule SymphonyElixir.CoreTest do
 
   test "in-repo WORKFLOW.md renders correctly" do
     workflow_path = Workflow.workflow_file_path()
+    previous_linear_api_key = System.get_env("LINEAR_API_KEY")
+
+    on_exit(fn -> restore_env("LINEAR_API_KEY", previous_linear_api_key) end)
+
+    System.put_env("LINEAR_API_KEY", "test-linear-api-key")
     Workflow.set_workflow_file_path(Path.expand("WORKFLOW.md", File.cwd!()))
 
     issue = %Issue{

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -134,6 +134,18 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert Config.settings!().polling.interval_ms == good_settings.polling.interval_ms
     assert {:error, {:invalid_workflow_config, _message}} = Config.validate!()
 
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "linear",
+      tracker_api_token: "token",
+      tracker_project_slug: nil,
+      prompt: "Semantic-invalid prompt"
+    )
+
+    assert {:error, :missing_linear_project_slug} = WorkflowStore.force_reload()
+    assert {:ok, %{prompt: "Second prompt"}} = Workflow.current()
+    assert Config.settings!().polling.interval_ms == good_settings.polling.interval_ms
+    assert {:error, :missing_linear_project_slug} = Config.validate!()
+
     third_workflow = Path.join(Path.dirname(Workflow.workflow_file_path()), "THIRD_WORKFLOW.md")
     write_workflow_file!(third_workflow, prompt: "Third prompt")
     Workflow.set_workflow_file_path(third_workflow)
@@ -194,14 +206,16 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert removed_state.workflow.prompt == "Manual workflow prompt"
     assert_receive :poll, 1_100
 
-    Process.exit(manual_pid, :normal)
+    assert :ok = GenServer.stop(manual_pid)
+
+    Workflow.set_workflow_file_path(existing_path)
+
     restart_result = Supervisor.restart_child(SymphonyElixir.Supervisor, WorkflowStore)
 
     assert match?({:ok, _pid}, restart_result) or
              match?({:error, {:already_started, _pid}}, restart_result)
 
-    Workflow.set_workflow_file_path(existing_path)
-    WorkflowStore.force_reload()
+    assert :ok = WorkflowStore.force_reload()
   end
 
   test "tracker delegates to memory and linear adapters" do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -801,7 +801,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
   test "orchestrator triggers an immediate poll cycle shortly after startup" do
     write_workflow_file!(Workflow.workflow_file_path(),
-      tracker_api_token: nil,
+      tracker_kind: "memory",
       poll_interval_ms: 5_000
     )
 
@@ -853,7 +853,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
   test "orchestrator poll cycle resets next refresh countdown after a check" do
     write_workflow_file!(Workflow.workflow_file_path(),
-      tracker_api_token: nil,
+      tracker_kind: "memory",
       poll_interval_ms: 50
     )
 
@@ -902,7 +902,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
   test "orchestrator restarts stalled workers with retry backoff" do
     write_workflow_file!(Workflow.workflow_file_path(),
-      tracker_api_token: nil,
+      tracker_kind: "memory",
       codex_stall_timeout_ms: 1_000
     )
 
@@ -943,6 +943,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       started_at: stale_activity_at
     }
 
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [running_entry.issue])
+
     :sys.replace_state(pid, fn _ ->
       initial_state
       |> Map.put(:running, %{issue_id => running_entry})
@@ -972,7 +974,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
   test "orchestrator blocks stalled workers that are waiting on MCP elicitation" do
     write_workflow_file!(Workflow.workflow_file_path(),
-      tracker_api_token: nil,
+      tracker_kind: "memory",
       codex_stall_timeout_ms: 1_000
     )
 
@@ -1019,6 +1021,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       started_at: stale_activity_at
     }
 
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [running_entry.issue])
+
     :sys.replace_state(pid, fn _ ->
       initial_state
       |> Map.put(:running, %{issue_id => running_entry})
@@ -1054,7 +1058,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
   end
 
   test "orchestrator blocks failed workers after app-server reports input required" do
-    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
 
     issue_id = "issue-input-required"
     orchestrator_name = Module.concat(__MODULE__, :InputRequiredBlockOrchestrator)
@@ -1086,6 +1090,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       started_at: started_at
     }
 
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [running_entry.issue])
+
     :sys.replace_state(pid, fn _ ->
       initial_state
       |> Map.put(:running, %{issue_id => running_entry})
@@ -1107,7 +1113,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
   end
 
   test "orchestrator blocks normal worker exits after input required completion" do
-    write_workflow_file!(Workflow.workflow_file_path(), tracker_api_token: nil)
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
 
     issue_id = "issue-input-required-normal"
     orchestrator_name = Module.concat(__MODULE__, :InputRequiredNormalBlockOrchestrator)
@@ -1134,6 +1140,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       last_codex_event: nil,
       started_at: DateTime.utc_now()
     }
+
+    Application.put_env(:symphony_elixir, :memory_tracker_issues, [running_entry.issue])
 
     :sys.replace_state(pid, fn _ ->
       initial_state

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -780,6 +780,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     System.delete_env("LINEAR_API_KEY")
 
     write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "memory",
       workspace_root: nil,
       max_concurrent_agents: nil,
       codex_approval_policy: nil,
@@ -1012,6 +1013,8 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
   test "config supports per-state max concurrent agent overrides" do
     workflow = """
     ---
+    tracker:
+      kind: memory
     agent:
       max_concurrent_agents: 10
       max_concurrent_agents_by_state:


### PR DESCRIPTION
#### Context

Symphony could start scheduling with semantically invalid workflow
settings, while blank required values also passed validation.

#### TL;DR

*Validate workflow settings before they become effective or start scheduling.*

#### Summary

- Make WorkflowStore cache only semantically valid workflow settings.
- Return startup errors before Orchestrator schedules cleanup or polling.
- Reject blank Linear settings and whitespace-only Codex commands.
- Keep last-good settings across invalid reloads and runtime restarts.
- Add cold-start, reload, restart, and test-bootstrap coverage.

#### Alternatives

- Validating only in Orchestrator init was rejected because bad reloads
  could break ordinary OTP restarts.
- Keeping validation only per tick was rejected because startup still
  appeared healthy with invalid settings.

#### Test Plan

- [x] `cd elixir && mise exec -- make all`
- [x] `cd elixir && mise exec -- mix test --seed 567691 --max-failures 1`
