### PR TITLE
Fix Burrito release tag verification

### DIFF
--- a/.github/workflows/burrito-release.yml
+++ b/.github/workflows/burrito-release.yml
@@ -126,6 +126,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Download release assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
#### Context

The v0.0.1 tag run built and smoke-tested every artifact, but release creation failed because the job had no Git checkout.

#### TL;DR

*Check out Git before verifying release tags.*

#### Summary

- Add checkout to the Burrito release job before running `gh release create --verify-tag`.

#### Alternatives

- Removing `--verify-tag` would hide tag mistakes instead of fixing the missing Git context.

#### Test Plan

- [x] `yq eval .github/workflows/burrito-release.yml`
- [x] `actionlint .github/workflows/burrito-release.yml`
- [x] `git diff --check`
