### PR TITLE
Add generic tracker interface with Linear adapter

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -15,9 +15,9 @@ behavior.
 
 ## 1. Problem Statement
 
-Symphony is a long-running automation service that continuously reads work from an issue tracker
-(Linear in this specification version), creates an isolated workspace for each issue, and runs a
-coding agent session for that issue inside the workspace.
+Symphony is a long-running automation service that continuously reads work from a configured issue
+tracker, creates an isolated workspace for each issue, and runs a coding agent session for that
+issue inside the workspace.
 
 The service solves four operational problems:
 
@@ -37,7 +37,9 @@ Important boundary:
 
 - Symphony is a scheduler/runner and tracker reader.
 - Ticket writes (state transitions, comments, PR links) are typically performed by the coding agent
-  using tools available in the workflow/runtime environment.
+  through provider-native tools executed by Symphony with the configured tracker credential.
+- When tracker credentials are supplied through host-side secret references, the coding-agent child
+  process does not need a duplicate tracker login or direct access to raw tracker credentials.
 - A successful run can end at a workflow-defined handoff state (for example `Human Review`), not
   necessarily `Done`.
 
@@ -80,11 +82,13 @@ Important boundary:
    - Applies defaults and environment variable indirection.
    - Performs validation used by the orchestrator before dispatch.
 
-3. `Issue Tracker Client`
+3. `Issue Tracker Adapter`
    - Fetches candidate issues in active states.
    - Fetches current states for specific issue IDs (reconciliation).
    - Fetches terminal-state issues during startup cleanup.
    - Normalizes tracker payloads into a stable issue model.
+   - MAY expose provider-native agent tools without adding provider-specific write APIs to the
+     orchestrator.
 
 4. `Orchestrator`
    - Owns the poll tick.
@@ -129,19 +133,21 @@ Symphony is easiest to port when kept in these layers:
 4. `Execution Layer` (workspace + agent subprocess)
    - Filesystem lifecycle, workspace preparation, coding-agent protocol.
 
-5. `Integration Layer` (Linear adapter)
+5. `Integration Layer` (selected tracker adapter)
    - API calls and normalization for tracker data.
+   - Provider-native agent tools and centralized tracker authentication.
 
 6. `Observability Layer` (logs + OPTIONAL status surface)
    - Operator visibility into orchestrator and agent behavior.
 
 ### 3.3 External Dependencies
 
-- Issue tracker API (Linear for `tracker.kind: linear` in this specification version).
+- One configured issue tracker API.
 - Local filesystem for workspaces and logs.
 - OPTIONAL workspace population tooling (for example Git CLI, if used).
 - Coding-agent executable that supports the targeted Codex app-server mode.
-- Host environment authentication for the issue tracker and coding agent.
+- Host environment authentication for the issue tracker and coding agent. Host-side tracker secret
+  environment variables SHOULD NOT be inherited by the coding-agent child process.
 
 ## 4. Core Domain Model
 
@@ -149,30 +155,44 @@ Symphony is easiest to port when kept in these layers:
 
 #### 4.1.1 Issue
 
-Normalized issue record used by orchestration, prompt rendering, and observability output.
+Normalized schedulable work item used by orchestration, prompt rendering, and observability output.
+The name `Issue` is generic in this specification; an adapter MAY map it from a ticket, card,
+project item, or another provider-native work object.
 
 Fields:
 
 - `id` (string)
-  - Stable tracker-internal ID.
+  - REQUIRED stable dispatch identity within the configured tracker scope.
+  - Opaque to the orchestrator. It MAY be a project-item or board-entry ID instead of the
+    provider's underlying ticket ID.
+- `native_ref` (object or null)
+  - OPTIONAL non-secret provider identifiers needed by provider-native tools.
+  - Opaque to the orchestrator and preserved for prompt/tool context.
 - `identifier` (string)
-  - Human-readable ticket key (example: `ABC-123`).
+  - REQUIRED human-readable ticket key (example: `ABC-123`).
+  - MUST be unique within the configured tracker scope because it names workspaces and
+    operator-facing routes. An adapter spanning multiple namespaces MUST disambiguate it.
 - `title` (string)
 - `description` (string or null)
 - `priority` (integer or null)
   - Lower numbers are higher priority in dispatch sorting.
 - `state` (string)
-  - Current tracker state name.
+  - REQUIRED current provider-native state name.
 - `branch_name` (string or null)
   - Tracker-provided branch metadata if available.
 - `url` (string or null)
+- `assignee_id` (string or null)
 - `labels` (list of strings)
   - Normalized to lowercase.
 - `blocked_by` (list of blocker refs)
-  - Each blocker ref contains:
+  - Best-effort provider metadata. Each blocker ref contains:
     - `id` (string or null)
     - `identifier` (string or null)
     - `state` (string or null)
+- `dispatchable` (boolean)
+  - REQUIRED adapter-derived eligibility for provider-specific rules that the generic scheduler
+    cannot infer safely, such as assignment, board membership, or blocker semantics.
+  - The orchestrator still applies configured state, label, claim, retry, and concurrency rules.
 - `created_at` (timestamp or null)
 - `updated_at` (timestamp or null)
 
@@ -275,14 +295,22 @@ Fields:
 ### 4.2 Stable Identifiers and Normalization Rules
 
 - `Issue ID`
-  - Use for tracker lookups and internal map keys.
+  - Use for tracker refresh calls and internal map keys.
+  - Treat it as an opaque dispatch identity; do not assume it is the provider's underlying ticket
+    ID.
+- `Native Ref`
+  - Preserve as opaque non-secret data for provider-native agent tools and prompt rendering.
+  - Never use it as an orchestrator map key or interpret provider-specific fields in core logic.
 - `Issue Identifier`
   - Use for human-readable logs and workspace naming.
+  - Require uniqueness within the configured tracker scope.
 - `Workspace Key`
   - Derive from `issue.identifier` by replacing any character not in `[A-Za-z0-9._-]` with `_`.
-  - Use the sanitized value for the workspace directory name.
+  - If sanitization changes the identifier, append a short stable hash of `issue.id` so two
+    distinct identifiers cannot collide after replacement.
+  - Use the resulting value for the workspace directory name.
 - `Normalized Issue State`
-  - Compare states after `lowercase`.
+  - Compare states after trimming surrounding whitespace and applying `lowercase`.
 - `Session ID`
   - Compose from coding-agent `thread_id` and `turn_id` as `<thread_id>-<turn_id>`.
 
@@ -349,24 +377,26 @@ Fields:
 
 - `kind` (string)
   - REQUIRED for dispatch.
-  - Current supported value: `linear`
-- `endpoint` (string)
-  - Default for `tracker.kind == "linear"`: `https://api.linear.app/graphql`
-- `api_key` (string)
-  - MAY be a literal token or `$VAR_NAME`.
-  - Canonical environment variable for `tracker.kind == "linear"`: `LINEAR_API_KEY`.
-  - If `$VAR_NAME` resolves to an empty string, treat the key as missing.
-- `project_slug` (string)
-  - REQUIRED for dispatch when `tracker.kind == "linear"`.
+  - Selects one implementation-supported tracker adapter.
+- `provider` (object)
+  - Default: `{}`.
+  - Adapter-owned configuration such as endpoint, scope/project selector, and credentials.
+  - Core Symphony MUST preserve unknown keys and MUST NOT prescribe one cross-provider credential
+    or scope schema.
+  - Each adapter MUST document its required keys, defaults, secret keys, `$VAR_NAME` support, and
+    validation errors.
+  - If a documented secret `$VAR_NAME` resolves to an empty string, treat that secret as missing.
 - `required_labels` (list of strings)
   - Default: `[]`.
   - An issue MUST contain every configured label to dispatch or continue.
   - Matching ignores case and surrounding whitespace.
   - A blank configured label matches no issue.
 - `active_states` (list of strings)
-  - Default: `Todo`, `In Progress`
+  - REQUIRED unless the selected adapter profile documents a default.
+  - Values are provider-native state names compared case-insensitively by the scheduler.
 - `terminal_states` (list of strings)
-  - Default: `Closed`, `Cancelled`, `Canceled`, `Duplicate`, `Done`
+  - REQUIRED unless the selected adapter profile documents a default.
+  - Values are provider-native state names compared case-insensitively by the scheduler.
 
 #### 5.3.2 `polling` (object)
 
@@ -426,7 +456,7 @@ Fields:
   - Changes SHOULD be re-applied at runtime and affect future retry scheduling.
 - `max_concurrent_agents_by_state` (map `state_name -> positive integer`)
   - Default: empty map.
-  - State keys are normalized (`lowercase`) for lookup.
+  - State keys are normalized (`trim + lowercase`) for lookup.
   - Invalid entries (non-positive or non-numeric) are ignored.
 
 #### 5.3.6 `codex` (object)
@@ -480,7 +510,7 @@ Template input variables:
 Fallback prompt behavior:
 
 - If the workflow prompt body is empty, the runtime MAY use a minimal default prompt
-  (`You are working on an issue from Linear.`).
+  (`You are working on an issue from the configured tracker.`).
 - Workflow file read/parse failures are configuration/validation errors and SHOULD NOT silently fall
   back to a prompt.
 
@@ -565,8 +595,8 @@ Validation checks:
 
 - Workflow file can be loaded and parsed.
 - `tracker.kind` is present and supported.
-- `tracker.api_key` is present after `$` resolution.
-- `tracker.project_slug` is present when REQUIRED by the selected tracker kind.
+- The selected adapter accepts `tracker.provider` after documented defaults and `$VAR`
+  resolution.
 - `codex.command` is present and non-empty.
 
 ### 6.4 Core Config Fields Summary (Cheat Sheet)
@@ -575,13 +605,11 @@ This section is intentionally redundant so a coding agent can implement the conf
 Extension fields are documented in the extension section that defines them. Core conformance does
 not require recognizing or validating extension fields unless that extension is implemented.
 
-- `tracker.kind`: string, REQUIRED, currently `linear`
-- `tracker.endpoint`: string, default `https://api.linear.app/graphql` when `tracker.kind=linear`
-- `tracker.api_key`: string or `$VAR`, canonical env `LINEAR_API_KEY` when `tracker.kind=linear`
-- `tracker.project_slug`: string, REQUIRED when `tracker.kind=linear`
+- `tracker.kind`: string, REQUIRED, selects one supported adapter
+- `tracker.provider`: object, default `{}`, adapter-owned endpoint/scope/auth settings
 - `tracker.required_labels`: list of strings, default `[]`
-- `tracker.active_states`: list of strings, default `["Todo", "In Progress"]`
-- `tracker.terminal_states`: list of strings, default `["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]`
+- `tracker.active_states`: list of provider-native state names, adapter-defined default
+- `tracker.terminal_states`: list of provider-native state names, adapter-defined default
 - `polling.interval_ms`: integer, default `30000`
 - `workspace.root`: path resolved to absolute, default `<system-temp>/symphony_workspaces`
 - `hooks.after_create`: shell script or null
@@ -726,19 +754,17 @@ An issue is dispatch-eligible only if all are true:
 
 - It has `id`, `identifier`, `title`, and `state`.
 - Its state is in `active_states` and not in `terminal_states`.
-- It is routed to this worker by the configured assignee and contains every
-  label in `tracker.required_labels`.
+- Its adapter-provided `dispatchable` value is `true`.
+- It contains every label in `tracker.required_labels`.
 - It is not already in `running`.
 - It is not already in `claimed`.
 - Global concurrency slots are available.
 - Per-state concurrency slots are available.
-- Blocker rule for `Todo` state passes:
-  - If the issue state is `Todo`, do not dispatch when any blocker is non-terminal.
 
 Sorting order (stable intent):
 
-1. `priority` ascending (1..4 are preferred; null/unknown sorts last)
-2. `created_at` oldest first
+1. `priority` ascending for values `1..4`; all other integers and null sort after that bucket
+2. `created_at` oldest first; null sorts last
 3. `identifier` lexicographic tie-breaker
 
 ### 8.3 Concurrency Control
@@ -1052,47 +1078,47 @@ Unsupported dynamic tool calls:
   using the targeted protocol and continue the session.
 - This prevents the session from stalling on unsupported tool execution paths.
 
-Optional client-side tool extension:
+Optional provider-native agent tool extension:
 
-- An implementation MAY expose a limited set of client-side tools to the app-server session.
-- Current standardized optional tool: `linear_graphql`.
-- If implemented, supported tools SHOULD be advertised to the app-server session during startup
-  using the protocol mechanism supported by the targeted Codex app-server version.
-- Unsupported tool names SHOULD still return a failure result using the targeted protocol and
+- An adapter MAY expose provider-native tools to the app-server session.
+- The selected adapter's tool specs SHOULD be advertised during session startup using the protocol
+  mechanism supported by the targeted Codex app-server version.
+- Tool specs, adapter selection, and effective tracker settings MUST be bound to one session
+  snapshot. A workflow reload applies to future sessions; it MUST NOT make an in-flight session
+  advertise one provider and execute another.
+- Tool names, schemas, and result payloads are adapter-owned. Symphony does not standardize a
+  lowest-common-denominator CRUD API.
+- The runtime MUST execute advertised tool calls host-side with the active adapter configuration and
+  MUST NOT require the coding-agent child process to read raw tracker tokens from disk or
+  environment.
+- The runtime SHOULD pass the current normalized issue to the adapter as internal execution context.
+  The adapter MAY use `issue.id` and `issue.native_ref` to preserve provider-specific richness
+  without teaching the orchestrator provider semantics.
+- Tracker credentials SHOULD NOT be inherited by the coding-agent child process. An adapter that
+  resolves credentials from environment variables MUST declare which secret environment names the
+  launcher removes from local and remote child environments. Literal credentials in a repo-owned
+  `WORKFLOW.md` remain readable to a child with workspace access and SHOULD NOT be used when this
+  isolation matters.
+- Unsupported tool names MUST return a structured failure result using the targeted protocol and
   continue the session.
+- Each adapter that ships tools MUST document:
+  - tool names and input schemas;
+  - whether a tool can mutate tracker state;
+  - scope/authorization behavior;
+  - result and error semantics;
+  - any provider-side idempotency or rate-limit expectations.
 
-`linear_graphql` extension contract:
+Minimal language-neutral adapter hooks for this OPTIONAL extension:
 
-- Purpose: execute a raw GraphQL query or mutation against Linear using Symphony's configured
-  tracker auth for the current session.
-- Availability: only meaningful when `tracker.kind == "linear"` and valid Linear auth is configured.
-- Preferred input shape:
+```text
+agent_tool_specs() -> list<ToolSpec>
+secret_environment_names() -> list<string>
+execute_agent_tool(name, arguments, context={issue}) -> ToolResult
+```
 
-  ```json
-  {
-    "query": "single GraphQL query or mutation document",
-    "variables": {
-      "optional": "graphql variables object"
-    }
-  }
-  ```
-
-- `query` MUST be a non-empty string.
-- `query` MUST contain exactly one GraphQL operation.
-- `variables` is OPTIONAL and, when present, MUST be a JSON object.
-- Implementations MAY additionally accept a raw GraphQL query string as shorthand input.
-- Execute one GraphQL operation per tool call.
-- If the provided document contains multiple operations, reject the tool call as invalid input.
-- `operationName` selection is intentionally out of scope for this extension.
-- Reuse the configured Linear endpoint and auth from the active Symphony workflow/runtime config; do
-  not require the coding agent to read raw tokens from disk.
-- Tool result semantics:
-  - transport success + no top-level GraphQL `errors` -> `success=true`
-  - top-level GraphQL `errors` present -> `success=false`, but preserve the GraphQL response body
-    for debugging
-  - invalid input, missing auth, or transport failure -> `success=false` with an error payload
-- Return the GraphQL response or error payload as structured tool output that the model can inspect
-  in-session.
+`ToolResult` MUST distinguish success from failure and carry JSON-safe structured output that can
+be translated to the targeted app-server protocol. The context contains the normalized issue, never
+the credential.
 
 User-input-required policy:
 
@@ -1138,71 +1164,109 @@ Note:
 
 - Workspaces are intentionally preserved after successful runs.
 
-## 11. Issue Tracker Integration Contract (Linear-Compatible)
+## 11. Issue Tracker Integration Contract
 
-### 11.1 REQUIRED Operations
+The issue tracker boundary is deliberately small: a portable read kernel for scheduling plus
+OPTIONAL provider-native agent tools. Do not add generic comment/state/attachment CRUD merely to
+make providers look alike; those operations lose useful provider semantics and are not needed by
+the orchestrator.
 
-An implementation MUST support these tracker adapter operations:
+### 11.1 REQUIRED Adapter Operations
 
-1. `fetch_candidate_issues()`
-   - Return issues in configured active states for a configured project.
+An implementation MUST support these adapter operations:
 
-2. `fetch_issues_by_states(state_names)`
-   - Used for startup terminal cleanup.
+1. `fetch_issues_by_states(state_names)`
+   - Return normalized issues visible in the configured tracker scope and requested state names.
+   - The adapter MUST apply provider-side scope selection and pagination.
+   - Used with configured active states for candidate polling and terminal states for startup
+     cleanup.
+   - When used for candidate polling, include active scoped issues even when
+     `dispatchable=false`; the scheduler owns that final filter.
+   - The orchestrator applies `required_labels`, `dispatchable`, claims, retries, and concurrency
+     after normalization.
+   - An empty `state_names` list MUST return an empty result without a provider request.
 
-3. `fetch_issue_states_by_ids(issue_ids)`
-   - Used for active-run reconciliation.
+2. `fetch_issues_by_ids(issue_ids)`
+   - Return current normalized issue snapshots for the supplied opaque dispatch IDs.
+   - Used for active-run reconciliation and stale-dispatch revalidation.
+   - An empty `issue_ids` list MUST return an empty result without a provider request.
+   - IDs no longer visible in the configured scope are omitted; the orchestrator treats omission as
+     "no longer visible" rather than inventing a synthetic state.
 
-### 11.2 Query Semantics (Linear)
+Both operations return either `ok(list<Issue>)` or a typed adapter error. They are atomic from
+the scheduler's perspective after a paging or transport failure. A state-list call MAY omit and log
+an individually malformed provider record because it was never safe to dispatch. An ID-refresh call
+MUST fail instead of silently omitting a malformed requested record, because omission is meaningful.
+A successful `fetch_issues_by_ids` result is complete for that call. Output order is not
+significant, input IDs are treated as a set, and each dispatch ID appears at most once.
 
-Linear-specific requirements for `tracker.kind == "linear"`:
+The refresh operation returns full normalized snapshots, not only state strings, because label,
+assignment, routing, and provider-specific dispatchability can change while a run is active.
 
-- `tracker.kind == "linear"`
-- GraphQL endpoint (default `https://api.linear.app/graphql`)
-- Auth token sent in `Authorization` header
-- `tracker.project_slug` maps to Linear project `slugId`
-- Candidate issue query filters project using `project: { slugId: { eq: $projectSlug } }`
-- Candidate and issue-state refresh queries include issue labels. Required
-  label filtering happens after normalization so refresh can observe label
-  removal and stop or release existing work.
-- Issue-state refresh query uses GraphQL issue IDs with variable type `[ID!]`
-- Pagination REQUIRED for candidate issues
-- Page size default: `50`
-- Network timeout: `30000 ms`
+### 11.2 Adapter Responsibilities
 
-Important:
+Each adapter owns:
 
-- Linear GraphQL schema details can drift. Keep query construction isolated and test the exact query
-  fields/types REQUIRED by this specification.
+- construction from the current effective tracker configuration, including active/terminal states;
+- endpoint, authentication, transport, timeouts, pagination, and rate-limit handling;
+- provider-specific scope selection (project, board, team, repository, query, or equivalent);
+- mapping provider payloads into the normalized Issue fields in Section 4.1.1;
+- choosing a stable dispatch identity and preserving any distinct underlying IDs in `native_ref`;
+- deriving `dispatchable` from provider-specific routing rules;
+- preserving provider-native state names while allowing case-insensitive scheduler comparison;
+- OPTIONAL provider-native agent tools and their authorization boundary.
 
-A non-Linear implementation MAY change transport details, but the normalized outputs MUST match the
-domain model in Section 4.
+The orchestrator MUST NOT inspect provider payloads, assume that `issue.id` is an underlying
+ticket ID, or branch on provider-specific blocker, board, transition, or comment semantics.
+
+Each adapter MUST document a compact profile containing:
+
+- supported `tracker.kind` value;
+- `tracker.provider` keys, defaults, secret keys, and validation errors;
+- scope selection and pagination behavior;
+- `id` and `native_ref` mapping;
+- state, label, priority, timestamp, and `dispatchable` normalization;
+- provider-native tool names/schemas if any;
+- typed transport/auth/rate-limit error categories.
 
 ### 11.3 Normalization Rules
 
-Candidate issue normalization SHOULD produce fields listed in Section 4.1.1.
+Adapter output MUST satisfy Section 4.1.1. In addition:
 
-Additional normalization details:
-
-- Label names are trimmed and lowercased.
-
-- `labels` -> lowercase strings
-- `blocked_by` -> derived from inverse relations where relation type is `blocks`
-- `priority` -> integer only (non-integers become null)
-- `created_at` and `updated_at` -> parse ISO-8601 timestamps
+- Every listed field MUST be present in the normalized record. Nullable fields use `null`;
+  collection fields use an empty list when absent.
+- `id`, `identifier`, `title`, and `state` MUST be non-empty strings.
+- `labels` MUST be trimmed, lowercased strings; blank labels MUST be dropped and duplicate labels
+  SHOULD be removed.
+- `priority` MUST be an integer or null.
+- The scheduler ranks priorities `1..4` before null/unknown values; other integers sort with
+  null/unknown unless an implementation documents a different mapping.
+- `created_at` and `updated_at` MUST represent parsed RFC 3339 instants or null; the in-memory
+  timestamp type is implementation-defined.
+- Preserve provider spelling in `state`, but trim and lowercase only for scheduler comparisons.
+- `blocked_by` is best-effort metadata; adapters MUST NOT invent blocker semantics they cannot
+  represent reliably.
+- `dispatchable` MUST be explicit. It is `true` only when provider-specific eligibility checks
+  pass; the generic scheduler never tries to reconstruct those checks from `native_ref`.
+- `native_ref` MUST be null or a JSON-safe object containing only non-secret values safe to expose
+  in prompt/tool context; preserve it verbatim.
 
 ### 11.4 Error Handling Contract
 
-RECOMMENDED error categories:
+RECOMMENDED adapter error categories:
 
 - `unsupported_tracker_kind`
-- `missing_tracker_api_key`
-- `missing_tracker_project_slug`
-- `linear_api_request` (transport failures)
-- `linear_api_status` (non-200 HTTP)
-- `linear_graphql_errors`
-- `linear_unknown_payload`
-- `linear_missing_end_cursor` (pagination integrity error)
+- `invalid_tracker_config`
+- `missing_tracker_secret`
+- `tracker_request` (transport failure)
+- `tracker_status` (non-success response)
+- `tracker_response` (malformed or semantically invalid payload)
+- `tracker_pagination` (pagination integrity failure)
+- `tracker_rate_limited`
+
+Every typed adapter error SHOULD include at least `category` and human-readable `message`.
+Adapters MAY add `retryable`, `retry_after_ms`, provider status, and provider-specific detail, but
+the orchestrator only relies on success vs. failure.
 
 Orchestrator behavior on tracker errors:
 
@@ -1210,17 +1274,19 @@ Orchestrator behavior on tracker errors:
 - Running-state refresh failure: log and keep active workers running.
 - Startup terminal cleanup failure: log warning and continue startup.
 
-### 11.5 Tracker Writes (Important Boundary)
+### 11.5 Tracker Writes and Agent Tools (Important Boundary)
 
 Symphony does not require first-class tracker write APIs in the orchestrator.
 
-- Ticket mutations (state transitions, comments, PR metadata) are typically handled by the coding
-  agent using tools defined by the workflow prompt.
+- Ticket mutations (state transitions, comments, attachments, PR metadata) are typically handled by
+  the coding agent through the selected adapter's provider-native tools.
+- Tools execute in Symphony with the configured adapter credential; the child receives tool results,
+  not a raw token.
+- The current normalized issue is available to tool execution as context, including opaque
+  `native_ref`, so adapters can retain provider richness without adding it to the core scheduler.
 - The service remains a scheduler/runner and tracker reader.
 - Workflow-specific success often means "reached the next handoff state" (for example
   `Human Review`) rather than tracker terminal state `Done`.
-- If the `linear_graphql` client-side tool extension is implemented, it is still part of the agent
-  toolchain rather than orchestrator business logic.
 
 ## 12. Prompt Construction and Context Assembly
 
@@ -1241,12 +1307,14 @@ Inputs to prompt rendering:
 
 ### 12.3 Retry/Continuation Semantics
 
-`attempt` SHOULD be passed to the template because the workflow prompt can provide different
-instructions for:
+`attempt` SHOULD be passed to the template as a 1-based retry/continuation count:
 
-- first run (`attempt` null or absent)
-- continuation run after a successful prior session
-- retry after error/timeout/stall
+- first run: `attempt` is null or absent;
+- any later run: `attempt` is an integer.
+
+The core `attempt` value does not distinguish a normal continuation from an error/timeout/stall
+retry. An implementation MAY expose an additional `retry_kind` template field if workflows need
+that distinction, but it is not part of core conformance.
 
 ### 12.4 Failure Semantics
 
@@ -1537,7 +1605,7 @@ API design notes:
 1. `Workflow/Config Failures`
    - Missing `WORKFLOW.md`
    - Invalid YAML front matter
-   - Unsupported tracker kind or missing tracker credentials/project slug
+   - Unsupported tracker kind or invalid adapter-owned tracker configuration
    - Missing coding-agent executable
 
 2. `Workspace Failures`
@@ -1649,6 +1717,12 @@ RECOMMENDED additional hardening for ports:
 - Support `$VAR` indirection in workflow config.
 - Do not log API tokens or secret env values.
 - Validate presence of secrets without printing them.
+- Execute provider-native tracker tools in the Symphony host process with the configured adapter
+  credential.
+- Do not pass tracker credentials through the coding-agent child environment. Adapters MUST declare
+  secret environment names so local and remote launchers can remove them from child environments.
+- Do not place literal tracker credentials in a repo-owned `WORKFLOW.md` when the child can read
+  that workspace; use host-side secret references instead.
 
 ### 15.4 Hook Script Safety
 
@@ -1679,10 +1753,10 @@ Possible hardening measures include:
   of running with a maximally permissive configuration.
 - Adding external isolation layers such as OS/container/VM sandboxing, network restrictions, or
   separate credentials beyond the built-in Codex policy controls.
-- Filtering which Linear issues, projects, teams, labels, or other tracker sources are eligible for
-  dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
-- Narrowing the `linear_graphql` tool so it can only read or mutate data inside the
-  intended project scope, rather than exposing general workspace-wide tracker access.
+- Filtering which issues, projects, boards, teams, labels, or other tracker sources are eligible
+  for dispatch so untrusted or out-of-scope tasks do not automatically reach the agent.
+- Narrowing provider-native tools so they can only read or mutate data inside the intended tracker
+  scope, rather than exposing general workspace-wide tracker access.
 - Reducing the set of client-side tools, credentials, filesystem paths, and network destinations
   available to the agent to the minimum needed for the workflow.
 
@@ -1734,7 +1808,7 @@ on_tick(state):
     schedule_tick(state.poll_interval_ms)
     return state
 
-  issues = tracker.fetch_candidate_issues()
+  issues = tracker.fetch_issues_by_states(active_states)
   if issues failed:
     log_tracker_error()
     notify_observers()
@@ -1763,7 +1837,7 @@ function reconcile_running_issues(state):
   if running_ids is empty:
     return state
 
-  refreshed = tracker.fetch_issue_states_by_ids(running_ids)
+  refreshed = tracker.fetch_issues_by_ids(running_ids)
   if refreshed failed:
     log_debug("keep workers running")
     return state
@@ -1775,6 +1849,10 @@ function reconcile_running_issues(state):
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)
+
+  returned_ids = set(issue.id for issue in refreshed)
+  for missing_id in running_ids - returned_ids:
+    state = terminate_running_issue(state, missing_id, cleanup_workspace=false)
 
   return state
 ```
@@ -1856,13 +1934,16 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
       run_hook_best_effort("after_run", workspace.path)
       fail_worker("agent turn error")
 
-    refreshed_issue = tracker.fetch_issue_states_by_ids([issue.id])
+    refreshed_issue = tracker.fetch_issues_by_ids([issue.id])
     if refreshed_issue failed:
       app_server.stop_session(session)
       run_hook_best_effort("after_run", workspace.path)
       fail_worker("issue state refresh error")
 
-    issue = refreshed_issue[0] or issue
+    if refreshed_issue is empty:
+      break
+
+    issue = refreshed_issue[0]
 
     if issue.state is not active:
       break
@@ -1907,19 +1988,23 @@ on_retry_timer(issue_id, state):
   if missing:
     return state
 
-  candidates = tracker.fetch_candidate_issues()
+  refreshed = tracker.fetch_issues_by_ids([issue_id])
   if fetch failed:
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: retry_entry.identifier,
-      error: "retry poll failed"
+      error: "retry refresh failed"
     })
 
-  issue = find_by_id(candidates, issue_id)
+  issue = find_by_id(refreshed, issue_id)
   if issue is null:
     state.claimed.remove(issue_id)
     return state
 
-  if available_slots(state) == 0:
+  if not retry_dispatch_allowed(issue, state, ignore_existing_claim=issue_id):
+    state.claimed.remove(issue_id)
+    return state
+
+  if no_available_slots(state):
     return schedule_retry(state, issue_id, retry_entry.attempt + 1, {
       identifier: issue.identifier,
       error: "no available orchestrator slots"
@@ -1956,9 +2041,9 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Invalid YAML front matter returns typed error
 - Front matter non-map returns typed error
 - Config defaults apply when OPTIONAL values are missing
-- `tracker.kind` validation enforces currently supported kind (`linear`)
-- `tracker.api_key` works (including `$VAR` indirection)
-- `$VAR` resolution works for tracker API key and path values
+- `tracker.kind` validation enforces an implementation-supported adapter
+- `tracker.provider` preserves adapter-owned keys and validates them through the selected adapter
+- `$VAR` resolution works for documented adapter secret keys and path values
 - `~` path expansion works
 - `codex.command` is preserved as a shell command string
 - Per-state concurrency override map normalizes state names and ignores invalid values
@@ -1980,23 +2065,24 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Workspace path sanitization and root containment invariants are enforced before agent launch
 - Agent launch uses the per-issue workspace path as cwd and rejects out-of-root paths
 
-### 17.3 Issue Tracker Client
+### 17.3 Issue Tracker Adapter
 
-- Candidate issue fetch uses active states and project slug
-- Linear query uses the specified project filter field (`slugId`)
-- Empty `fetch_issues_by_states([])` returns empty without API call
+- Candidate issue fetch applies configured active states and adapter-owned scope selection
+- Empty `fetch_issues_by_states([])` returns empty without a provider call
+- Empty `fetch_issues_by_ids([])` returns empty without a provider call
 - Pagination preserves order across multiple pages
-- Blockers are normalized from inverse relations of type `blocks`
 - Labels are normalized to lowercase
-- Issue state refresh by ID returns minimal normalized issues
-- Issue state refresh query uses GraphQL ID typing (`[ID!]`) as specified in Section 11.2
-- Error mapping for request errors, non-200, GraphQL errors, malformed payloads
+- Refresh by opaque dispatch ID returns full normalized issue snapshots
+- A distinct provider ticket ID or project-item ID is preserved in `native_ref` when needed
+- Provider-specific routing/blocker/assignment rules become explicit `dispatchable`
+- Error mapping covers config, request, non-success response, malformed payload, pagination, and
+  rate limiting
 
 ### 17.4 Orchestrator Dispatch, Reconciliation, and Retry
 
 - Dispatch sort order is priority then oldest creation time
-- `Todo` issue with non-terminal blockers is not eligible
-- `Todo` issue with terminal blockers is eligible
+- `dispatchable=false` issues are not eligible
+- Required-label filtering is case-insensitive and applies after adapter normalization
 - Active-state issue refresh updates running entry state
 - Non-active state stops running agent without workspace cleanup
 - Terminal state stops running agent and cleans workspace
@@ -2033,10 +2119,11 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
   targeted protocol
 - If client-side tools are implemented, session startup advertises the supported tool specs
   using the targeted app-server protocol
-- If the `linear_graphql` client-side tool extension is implemented:
-  - the tool is advertised to the session
-  - valid `query` / `variables` inputs execute against configured Linear auth
-  - top-level GraphQL `errors` produce `success=false` while preserving the GraphQL body
+- If provider-native agent tools are implemented:
+  - only the selected adapter's tools are advertised to the session
+  - valid inputs execute host-side with configured adapter auth
+  - the current normalized issue and `native_ref` are available as internal tool context
+  - tracker secrets are not inherited by the coding-agent child process
   - invalid arguments, missing auth, and transport failures return structured failure payloads
   - unsupported tool names still fail without stalling the session
 
@@ -2065,8 +2152,8 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 These checks are RECOMMENDED for production readiness and MAY be skipped in CI when credentials,
 network access, or external service permissions are unavailable.
 
-- A real tracker smoke test can be run with valid credentials supplied by `LINEAR_API_KEY` or a
-  documented local bootstrap mechanism (for example `~/.linear_api_key`).
+- A real tracker smoke test can be run with valid credentials supplied through the selected
+  adapter's documented secret mechanism.
 - Real integration tests SHOULD use isolated test identifiers/workspaces and clean up tracker
   artifacts when practical.
 - A skipped real-integration test SHOULD be reported as skipped, not silently treated as passed.
@@ -2088,11 +2175,11 @@ Use the same validation profiles as Section 17:
 - Typed config layer with defaults and `$` resolution
 - Dynamic `WORKFLOW.md` watch/reload/re-apply for config and prompt
 - Polling orchestrator with single-authority mutable state
-- Issue tracker client with candidate fetch + state refresh + terminal fetch
+- Issue tracker adapter with state-list + ID-refresh reads
 - Workspace manager with sanitized per-issue workspaces
 - Workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`)
 - Hook timeout config (`hooks.timeout_ms`, default `60000`)
-- Coding-agent app-server subprocess client with JSON line protocol
+- Coding-agent app-server subprocess client with the targeted transport/framing protocol
 - Codex launch command config (`codex.command`, default `codex app-server`)
 - Strict prompt rendering with `issue` and `attempt` variables
 - Exponential retry queue with continuation retries after normal exit
@@ -2106,14 +2193,13 @@ Use the same validation profiles as Section 17:
 
 - HTTP server extension honors CLI `--port` over `server.port`, uses a safe default bind host, and
   exposes the baseline endpoints/error semantics in Section 13.7 if shipped.
-- `linear_graphql` client-side tool extension exposes raw Linear GraphQL access through the
-  app-server session using configured Symphony auth.
+- Provider-native agent tools, when shipped, execute through the app-server session using
+  host-side configured adapter auth without passing tracker secrets to the child.
 - TODO: Persist retry queue and session metadata across process restarts.
 - TODO: Make observability settings configurable in workflow front matter without prescribing UI
   implementation details.
-- TODO: Add first-class tracker write APIs (comments/state transitions) in the orchestrator instead
-  of only via agent tools.
-- TODO: Add pluggable issue tracker adapters beyond Linear.
+- TODO: Extract common semantic helper tools only after multiple adapters demonstrate real
+  duplication; do not preemptively replace provider-native tools with generic CRUD.
 
 ### 18.3 Operational Validation Before Production (RECOMMENDED)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -225,7 +225,7 @@ Filesystem workspace assigned to one issue identifier.
 Fields (logical):
 
 - `path` (absolute workspace path)
-- `workspace_key` (sanitized issue identifier)
+- `workspace_key` (collision-resistant sanitized issue identifier)
 - `created_now` (boolean, used to gate `after_create` hook)
 
 #### 4.1.5 Run Attempt
@@ -306,8 +306,9 @@ Fields:
   - Require uniqueness within the configured tracker scope.
 - `Workspace Key`
   - Derive from `issue.identifier` by replacing any character not in `[A-Za-z0-9._-]` with `_`.
-  - If sanitization changes the identifier, append a short stable hash of `issue.id` so two
-    distinct identifiers cannot collide after replacement.
+  - If sanitization changes the identifier, append a stable hash suffix of the original identifier
+    with at least 64 bits of entropy using only allowed workspace-key characters, making keys for
+    distinct identifiers that sanitize to the same text collision-resistant.
   - Use the resulting value for the workspace directory name.
 - `Normalized Issue State`
   - Compare states after trimming surrounding whitespace and applying `lowercase`.
@@ -538,11 +539,13 @@ Configuration is resolved in this order:
 1. Select the workflow file path (explicit runtime setting, otherwise cwd default).
 2. Parse YAML front matter into a raw config map.
 3. Apply built-in defaults for missing OPTIONAL fields.
-4. Resolve `$VAR_NAME` indirection only for config values that explicitly contain `$VAR_NAME`.
+4. Resolve `$VAR_NAME` indirection for config values that explicitly contain `$VAR_NAME`, plus any
+   adapter-owned fallback environment names documented for omitted provider fields.
 5. Coerce and validate typed values.
 
 Environment variables do not globally override YAML values. They are used only when a config value
-explicitly references them.
+explicitly references them, or when an adapter profile documents a host-side fallback for an
+omitted provider field. Such a fallback is adapter-local, not a cross-provider convention.
 
 Value coercion semantics:
 
@@ -761,6 +764,10 @@ An issue is dispatch-eligible only if all are true:
 - Global concurrency slots are available.
 - Per-state concurrency slots are available.
 
+For refresh and continuation checks, `issue_routable(issue)` means only that adapter-provided
+`dispatchable` is true and all `tracker.required_labels` match. State, claims, and concurrency are
+checked separately by the surrounding algorithm.
+
 Sorting order (stable intent):
 
 1. `priority` ascending for values `1..4`; all other integers and null sort after that bucket
@@ -795,20 +802,19 @@ Backoff formula:
 
 Retry handling behavior:
 
-1. Fetch active candidate issues (not all issues).
-2. Find the specific issue by `issue_id`.
-3. If not found, release claim.
-4. If found and still candidate-eligible:
+1. Refresh the specific issue with `fetch_issues_by_ids([issue_id])`.
+2. If not found, release claim.
+3. If found in a terminal state, clean its workspace and release claim.
+4. If found and still active and routable:
    - Dispatch if slots are available.
    - Otherwise requeue with error `no available orchestrator slots`.
-5. If found but no longer active, release claim.
+5. If found but no longer active or routable, release claim without dispatch.
 
 Note:
 
-- Terminal-state workspace cleanup is handled by startup cleanup and active-run reconciliation
-  (including terminal transitions for currently running issues).
-- Retry handling mainly operates on active candidates and releases claims when the issue is absent,
-  rather than performing terminal cleanup itself.
+- Terminal-state workspace cleanup is handled by startup cleanup, active-run reconciliation, and
+  retry refreshes that observe a terminal transition.
+- ID refresh avoids treating a terminal, non-active, or newly unroutable issue as merely absent.
 
 ### 8.5 Active Run Reconciliation
 
@@ -827,7 +833,8 @@ Part B: Tracker state refresh
 - Fetch current issue states for all running issue IDs.
 - For each running issue:
   - If tracker state is terminal: terminate worker and clean workspace.
-  - If tracker state is still active: update the in-memory issue snapshot.
+  - If tracker state is still active and routable: update the in-memory issue snapshot.
+  - If tracker state is active but no longer routable: terminate worker without workspace cleanup.
   - If tracker state is neither active nor terminal: terminate worker without workspace cleanup.
 - If state refresh fails, keep workers running and try again on the next tick.
 
@@ -851,7 +858,7 @@ Workspace root:
 
 Per-issue workspace path:
 
-- `<workspace.root>/<sanitized_issue_identifier>`
+- `<workspace.root>/<workspace_key>`
 
 Workspace persistence:
 
@@ -864,7 +871,8 @@ Input: `issue.identifier`
 
 Algorithm summary:
 
-1. Sanitize identifier to `workspace_key`.
+1. Derive `workspace_key` using Section 4.2, including the stable original-identifier hash when
+   sanitization changes the identifier.
 2. Compute workspace path under workspace root.
 3. Ensure the workspace path exists as a directory.
 4. Mark `created_now=true` only if the directory was created during this call; otherwise
@@ -936,6 +944,8 @@ Invariant 3: Workspace key is sanitized.
 
 - Only `[A-Za-z0-9._-]` allowed in workspace directory names.
 - Replace all other characters with `_`.
+- If replacement changes the identifier, append a stable original-identifier hash suffix with at
+  least 64 bits of entropy so keys remain collision-resistant after sanitization.
 
 ## 10. Agent Runner Protocol (Coding Agent Integration)
 
@@ -1193,12 +1203,24 @@ An implementation MUST support these adapter operations:
    - IDs no longer visible in the configured scope are omitted; the orchestrator treats omission as
      "no longer visible" rather than inventing a synthetic state.
 
-Both operations return either `ok(list<Issue>)` or a typed adapter error. They are atomic from
-the scheduler's perspective after a paging or transport failure. A state-list call MAY omit and log
-an individually malformed provider record because it was never safe to dispatch. An ID-refresh call
-MUST fail instead of silently omitting a malformed requested record, because omission is meaningful.
-A successful `fetch_issues_by_ids` result is complete for that call. Output order is not
-significant, input IDs are treated as a set, and each dispatch ID appears at most once.
+Both operations return either `ok(list<Issue>)` or an adapter error. For portability, an adapter
+error SHOULD expose a stable category and human-readable message. An implementation MAY use a
+language-native tagged error, exception, tuple, or enum instead of a literal error object when its
+adapter profile documents how those public error forms map to category and message. The
+orchestrator relies only on success versus failure.
+
+The operations are atomic from the scheduler's perspective after a paging or transport failure. For
+these rules, a record is malformed only when the adapter cannot produce the required normalized
+fields (`id`, `identifier`, `title`, `state`, and explicit `dispatchable`) or cannot produce a
+valid `Issue` after applying the optional-field fallback rules in Section 11.3. Unusable nullable
+or best-effort provider metadata MAY normalize to `null`, an empty list, or omitted best-effort
+entries; that fallback alone does not make a record malformed.
+
+A state-list call MAY omit an individually malformed provider record because it was never safe to
+dispatch, and SHOULD log that omission. An ID-refresh call MUST fail instead of silently omitting a
+malformed requested record, because omission is meaningful. A successful
+`fetch_issues_by_ids` result is complete for that call. Output order is not significant, input IDs
+are treated as a set, and each dispatch ID appears at most once.
 
 The refresh operation returns full normalized snapshots, not only state strings, because label,
 assignment, routing, and provider-specific dispatchability can change while a run is active.
@@ -1219,15 +1241,18 @@ Each adapter owns:
 The orchestrator MUST NOT inspect provider payloads, assume that `issue.id` is an underlying
 ticket ID, or branch on provider-specific blocker, board, transition, or comment semantics.
 
-Each adapter MUST document a compact profile containing:
+Each adapter MUST publish a compact profile in implementation documentation, not only code,
+containing:
 
-- supported `tracker.kind` value;
-- `tracker.provider` keys, defaults, secret keys, and validation errors;
-- scope selection and pagination behavior;
+- exact supported `tracker.kind` value;
+- exact `tracker.provider` keys, defaults, secret keys/environment names, and validation errors;
+- scope selection, pagination behavior, and provider request limits;
 - `id` and `native_ref` mapping;
-- state, label, priority, timestamp, and `dispatchable` normalization;
-- provider-native tool names/schemas if any;
-- typed transport/auth/rate-limit error categories.
+- state, label, priority, timestamp, `dispatchable`, malformed-record, and optional-field
+  normalization;
+- provider-native tool names/schemas, mutation capability, scope, and result/error behavior if any;
+- mapping from public language-native error forms to portable transport/auth/rate-limit error
+  categories and human-readable messages.
 
 ### 11.3 Normalization Rules
 
@@ -1243,13 +1268,18 @@ Adapter output MUST satisfy Section 4.1.1. In addition:
   null/unknown unless an implementation documents a different mapping.
 - `created_at` and `updated_at` MUST represent parsed RFC 3339 instants or null; the in-memory
   timestamp type is implementation-defined.
+- Unusable provider values for nullable fields MAY normalize to `null`. Unusable best-effort
+  collection entries MAY be dropped; if no usable entries remain, use an empty list. These
+  fallbacks MUST NOT be used for `id`, `identifier`, `title`, `state`, or explicit
+  `dispatchable`.
 - Preserve provider spelling in `state`, but trim and lowercase only for scheduler comparisons.
 - `blocked_by` is best-effort metadata; adapters MUST NOT invent blocker semantics they cannot
   represent reliably.
 - `dispatchable` MUST be explicit. It is `true` only when provider-specific eligibility checks
   pass; the generic scheduler never tries to reconstruct those checks from `native_ref`.
 - `native_ref` MUST be null or a JSON-safe object containing only non-secret values safe to expose
-  in prompt/tool context; preserve it verbatim.
+  in prompt/tool context. If provider metadata cannot be represented safely, normalize
+  `native_ref` to null; otherwise preserve the retained object verbatim.
 
 ### 11.4 Error Handling Contract
 
@@ -1264,9 +1294,10 @@ RECOMMENDED adapter error categories:
 - `tracker_pagination` (pagination integrity failure)
 - `tracker_rate_limited`
 
-Every typed adapter error SHOULD include at least `category` and human-readable `message`.
-Adapters MAY add `retryable`, `retry_after_ms`, provider status, and provider-specific detail, but
-the orchestrator only relies on success vs. failure.
+For portability, every adapter profile MUST document how each public language-native error form
+maps to a stable `category` and human-readable `message`. A literal `{category, message}`
+object is not required. Adapters MAY add `retryable`, `retry_after_ms`, provider status, and
+provider-specific detail, but the orchestrator only relies on success vs. failure.
 
 Orchestrator behavior on tracker errors:
 
@@ -1623,10 +1654,10 @@ API design notes:
    - Stalled session (no activity)
 
 4. `Tracker Failures`
-   - API transport errors
-   - Non-200 status
-   - GraphQL errors
-   - malformed payloads
+   - Provider transport errors
+   - Non-success provider responses
+   - Provider-reported application errors
+   - Malformed payloads
 
 5. `Observability Failures`
    - Snapshot timeout
@@ -1845,7 +1876,7 @@ function reconcile_running_issues(state):
   for issue in refreshed:
     if issue.state in terminal_states:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=true)
-    else if issue.state in active_states:
+    else if issue.state in active_states and issue_routable(issue):
       state.running[issue.id].issue = issue
     else:
       state = terminate_running_issue(state, issue.id, cleanup_workspace=false)
@@ -1945,7 +1976,7 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
 
     issue = refreshed_issue[0]
 
-    if issue.state is not active:
+    if issue.state is not active or not issue_routable(issue):
       break
 
     if turn_number >= max_turns:
@@ -2062,7 +2093,10 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - `before_run` hook runs before each attempt and failure/timeouts abort the current attempt
 - `after_run` hook runs after each attempt and failure/timeouts are logged and ignored
 - `before_remove` hook runs on cleanup and failures/timeouts are ignored
-- Workspace path sanitization and root containment invariants are enforced before agent launch
+- Workspace path sanitization, stable original-identifier-hash collision resistance, and root
+  containment invariants are enforced before agent launch
+- Identifiers unchanged by sanitization keep their deterministic workspace key; conformance tests
+  include distinct identifiers that sanitize to the same text and verify distinct keys
 - Agent launch uses the per-issue workspace path as cwd and rejects out-of-root paths
 
 ### 17.3 Issue Tracker Adapter
@@ -2072,11 +2106,16 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - Empty `fetch_issues_by_ids([])` returns empty without a provider call
 - Pagination preserves order across multiple pages
 - Labels are normalized to lowercase
+- Unusable optional provider metadata normalizes to null/empty without hiding valid required fields
+- State-list reads log omitted malformed required records; ID refresh fails malformed requested
+  records instead of treating them as invisible
 - Refresh by opaque dispatch ID returns full normalized issue snapshots
 - A distinct provider ticket ID or project-item ID is preserved in `native_ref` when needed
 - Provider-specific routing/blocker/assignment rules become explicit `dispatchable`
+- The adapter publishes the required compact profile for config, scope, normalization, tools, and
+  portable error mapping
 - Error mapping covers config, request, non-success response, malformed payload, pagination, and
-  rate limiting
+  rate limiting, including documented category/message mappings for language-native errors
 
 ### 17.4 Orchestrator Dispatch, Reconciliation, and Retry
 
@@ -2176,7 +2215,7 @@ Use the same validation profiles as Section 17:
 - Dynamic `WORKFLOW.md` watch/reload/re-apply for config and prompt
 - Polling orchestrator with single-authority mutable state
 - Issue tracker adapter with state-list + ID-refresh reads
-- Workspace manager with sanitized per-issue workspaces
+- Workspace manager with sanitized, collision-resistant per-issue workspaces
 - Workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`)
 - Hook timeout config (`hooks.timeout_ms`, default `60000`)
 - Coding-agent app-server subprocess client with the targeted transport/framing protocol

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -13,15 +13,17 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 ## How it works
 
-1. Polls Linear for candidate work
+1. Polls the configured tracker for candidate work (the included production adapter is Linear)
 2. Creates a workspace per issue
 3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
    workspace
 4. Sends a workflow prompt to Codex
 5. Keeps Codex working on the issue until the work is done
 
-During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that repo
-skills can make raw Linear GraphQL calls.
+During app-server sessions, the selected tracker adapter may advertise provider-native tools. The
+included Linear adapter serves `linear_graphql` so repo skills can make raw Linear GraphQL calls.
+Symphony executes that tool with its configured auth and removes `LINEAR_API_KEY` from the Codex
+child environment, so the agent does not need a second tracker login.
 
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
@@ -29,7 +31,7 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
 If Codex reports that operator input, approval, or MCP elicitation is required, Symphony keeps the
 issue claimed and exposes it as blocked in the runtime state, JSON API, and dashboard. Blocked
 entries are in memory only; restarting the orchestrator clears that blocked map, so any still-active
-Linear issue can become a dispatch candidate again after restart.
+tracker issue can become a dispatch candidate again after restart.
 
 ## How to use it
 
@@ -74,7 +76,7 @@ mise exec -- ./bin/symphony ./WORKFLOW.md
 
 Symphony ships self-contained executables built with
 [Burrito](https://github.com/burrito-elixir/burrito). They embed Erlang/OTP, Elixir, and Symphony,
-but still expect `codex`, `git`, and Linear credentials on the target machine.
+but still expect `codex`, `git`, and the selected tracker credentials on the target machine.
 
 Supported release targets:
 
@@ -117,7 +119,8 @@ Minimal example:
 ---
 tracker:
   kind: linear
-  project_slug: "..."
+  provider:
+    project_slug: "..."
 workspace:
   root: ~/code/workspaces
 hooks:
@@ -130,7 +133,7 @@ codex:
   command: codex app-server
 ---
 
-You are working on a Linear issue {{ issue.identifier }}.
+You are working on an issue from the configured tracker {{ issue.identifier }}.
 
 Title: {{ issue.title }} Body: {{ issue.description }}
 ```
@@ -138,6 +141,9 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used.
+- `tracker.kind` selects an adapter. Adapter-owned endpoint, scope, and auth settings belong under
+  `tracker.provider`; the current Linear adapter still accepts the older flat `endpoint`,
+  `api_key`, `project_slug`, and `assignee` aliases for compatibility.
 - `tracker.required_labels` is optional. When set, an issue must have every
   configured label to dispatch or continue running. Label matching ignores
   case and surrounding whitespace. A blank configured label matches no issue.
@@ -161,7 +167,11 @@ Notes:
   `git clone ... .` there, along with any other setup commands you need.
 - If a hook needs `mise exec` inside a freshly cloned workspace, trust the repo config and fetch
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
-- `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
+- For the Linear adapter, `tracker.provider.api_key` reads from `LINEAR_API_KEY` when unset or
+  when value is `$LINEAR_API_KEY`. The legacy flat `tracker.api_key` alias behaves the same way.
+- Do not put a literal tracker token in a repo-owned `WORKFLOW.md` if Codex can read that
+  workspace. Use `$VAR`/host-side secret references so Symphony can keep the token out of the
+  child environment.
 - For path values, `~` is expanded to the home directory.
 - For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling,
   while `codex.command` stays a shell command string and any `$VAR` expansion there happens in the
@@ -169,7 +179,8 @@ Notes:
 
 ```yaml
 tracker:
-  api_key: $LINEAR_API_KEY
+  provider:
+    api_key: $LINEAR_API_KEY
 workspace:
   root: $SYMPHONY_WORKSPACE_ROOT
 hooks:

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -196,6 +196,48 @@ codex:
 - `server.port` or CLI `--port` enables the optional Phoenix LiveView dashboard and JSON API at
   `/`, `/api/v1/state`, `/api/v1/<issue_identifier>`, and `/api/v1/refresh`.
 
+### Linear adapter profile
+
+- Config: use `tracker.kind: linear` with `tracker.provider.endpoint` (default
+  `https://api.linear.app/graphql`), `api_key` (defaults to `LINEAR_API_KEY` and accepts
+  `$VAR`), required `project_slug`, and optional `assignee` (a Linear user ID or `me`,
+  defaulting to `LINEAR_ASSIGNEE`).
+  The legacy flat `tracker.endpoint`, `api_key`, `project_slug`, and `assignee` aliases remain
+  supported. `required_labels`, `active_states`, and `terminal_states` stay under `tracker`.
+- Scope and paging: candidate reads filter the configured project slug and requested state names,
+  following Linear pages of 50. ID refreshes are also project-scoped and batch up to 50 IDs. Empty
+  state/ID lists return `{:ok, []}` without a Linear request.
+- Identity and normalization: `issue.id` is the Linear issue ID and `issue.native_ref` is currently
+  `nil`. Records missing a nonblank ID, identifier, title, or state are dropped from candidate
+  pages and fail ID refreshes. State keeps Linear's spelling; integer priorities are preserved and
+  other priority values become `nil`; RFC 3339 timestamps are parsed and unusable timestamps become
+  `nil`. Labels are trimmed, lowercased, deduplicated, and blanks are dropped; blockers come from
+  inverse `blocks` relations.
+- Dispatchability: the adapter marks an issue dispatchable only when optional assignee routing
+  matches and a `Todo` issue has no non-terminal blocker. The generic scheduler then applies
+  active/terminal states, required labels, claims, retries, and concurrency.
+- Tool: the Linear adapter advertises `linear_graphql`, accepting either a raw query string or an
+  object with nonblank `query` and optional object `variables`. Symphony executes it host-side
+  with the session-bound endpoint/token and strips declared token environment variables from the
+  Codex child. `project_slug` scopes scheduler reads, not raw tool calls; the tool can access
+  whatever the configured Linear token can access.
+- Responsibility and errors: `linear_graphql` adds no idempotency key, retry, scope guard, or
+  rate-limit policy, so workflows own idempotent mutations and handling provider errors. Read/config
+  failures use `{:error, :missing_linear_api_token}`, `{:error, :missing_linear_project_slug}`,
+  `{:error, :invalid_linear_endpoint}`, `{:error, :invalid_linear_assignee}`,
+  `{:error, :missing_linear_viewer_identity}`, `{:error, {:linear_api_status, status}}`,
+  `{:error, {:linear_api_request, reason}}`, `{:error, {:linear_graphql_errors, errors}}`,
+  `{:error, :linear_unknown_payload}`, or `{:error, :linear_missing_end_cursor}`. Tool results
+  are maps with `"success"`, JSON-string `"output"`, and text `"contentItems"`; invalid
+  arguments, missing auth, and transport failures return `"success" => false` with
+  `{"error": {"message": ...}}`, while top-level GraphQL errors preserve the response body with
+  `"success" => false`.
+  For portable reporting, map missing/invalid token, project, endpoint, assignee, or viewer errors
+  to `tracker_config` or `tracker_auth`, request failures to `tracker_transport`, non-200 responses to
+  `tracker_response` (`429` is `tracker_rate_limited`), GraphQL/unknown payload failures to
+  `tracker_payload`, and missing cursors to `tracker_pagination`; logs and tool responses carry the
+  human-readable provider detail.
+
 ## Web dashboard
 
 The observability UI now runs on a minimal Phoenix stack:

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -1,7 +1,8 @@
 ---
 tracker:
   kind: linear
-  project_slug: "symphony-0c79b11b75ea"
+  provider:
+    project_slug: "symphony-0c79b11b75ea"
   required_labels: []
   active_states:
     - Todo
@@ -41,12 +42,12 @@ codex:
 You are working on a Linear ticket `{{ issue.identifier }}`
 
 {% if attempt %}
-Continuation context:
+Follow-up context:
 
-- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
+- This is follow-up attempt #{{ attempt }}. It may be a normal continuation or a retry after a failure.
 - Resume from the current workspace state instead of restarting from scratch.
 - Do not repeat already-completed investigation or validation unless needed for new code changes.
-- Do not end the turn while the issue remains in an active state unless you are blocked by missing required permissions/secrets.
+- Do not end the turn while the work item remains in an active state unless you are blocked by missing required access.
   {% endif %}
 
 Issue context:
@@ -65,15 +66,15 @@ No description provided.
 
 Instructions:
 
-1. This is an unattended orchestration session. Never ask a human to perform follow-up actions.
-2. Only stop early for a true blocker (missing required auth/permissions/secrets). If blocked, record it in the workpad and move the issue according to workflow.
+1. This is an unattended orchestration session. Do not ask a human to perform follow-up actions.
+2. Only stop early for a true external blocker (missing required tools, auth, permissions, or secrets). If blocked, record it in the workpad and move the issue according to the workflow.
 3. Final message must report completed actions and blockers only. Do not include "next steps for user".
 
 Work only in the provided repository copy. Do not touch any other path.
 
 ## Prerequisite: Linear MCP or `linear_graphql` tool is available
 
-The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If none are present, stop and ask the user to configure Linear.
+The agent should be able to talk to Linear, either via a configured Linear MCP server or injected `linear_graphql` tool. If neither is present, treat that as blocked access: record it in the workpad and move the issue according to the workflow instead of asking a user to configure Linear.
 
 ## Default posture
 

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
   end
 
   defp closing_comment(branch) do
-    "Closing because the Linear issue for branch #{branch} entered a terminal state without merge."
+    "Closing because the tracker issue for branch #{branch} entered a terminal state without merge."
   end
 
   defp format_output(""), do: ""

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -1,11 +1,12 @@
 defmodule SymphonyElixir.AgentRunner do
   @moduledoc """
-  Executes a single Linear issue in its workspace with Codex.
+  Executes a single tracker work item in its workspace with Codex.
   """
 
   require Logger
   alias SymphonyElixir.Codex.AppServer
-  alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
+  alias SymphonyElixir.{Config, PromptBuilder, Tracker, Workspace}
+  alias SymphonyElixir.Tracker.Issue
 
   @type worker_host :: String.t() | nil
 
@@ -86,7 +87,7 @@ defmodule SymphonyElixir.AgentRunner do
 
   defp run_codex_turns(workspace, issue, codex_update_recipient, opts, worker_host) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
-    issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
+    issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issues_by_ids/1)
 
     with {:ok, session} <- AppServer.start_session(workspace, worker_host: worker_host) do
       try do
@@ -144,7 +145,7 @@ defmodule SymphonyElixir.AgentRunner do
     """
     Continuation guidance:
 
-    - The previous Codex turn completed normally, but the Linear issue is still in an active state.
+    - The previous Codex turn completed normally, but the tracker work item is still in an active state.
     - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
     - Resume from the current workspace and workpad state instead of restarting from scratch.
     - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -22,7 +22,8 @@ defmodule SymphonyElixir.Codex.AppServer do
           turn_sandbox_policy: map(),
           thread_id: String.t(),
           workspace: Path.t(),
-          worker_host: String.t() | nil
+          worker_host: String.t() | nil,
+          dynamic_tool_binding: map()
         }
 
   @spec run(Path.t(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
@@ -39,13 +40,15 @@ defmodule SymphonyElixir.Codex.AppServer do
   @spec start_session(Path.t(), keyword()) :: {:ok, session()} | {:error, term()}
   def start_session(workspace, opts \\ []) do
     worker_host = Keyword.get(opts, :worker_host)
+    dynamic_tool_binding = DynamicTool.bind()
 
     with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace, worker_host),
-         {:ok, port} <- start_port(expanded_workspace, worker_host) do
+         {:ok, port} <- start_port(expanded_workspace, worker_host, dynamic_tool_binding) do
       metadata = port_metadata(port, worker_host)
 
       with {:ok, session_policies} <- session_policies(expanded_workspace, worker_host),
-           {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_policies) do
+           {:ok, thread_id} <-
+             do_start_session(port, expanded_workspace, session_policies, dynamic_tool_binding) do
         {:ok,
          %{
            port: port,
@@ -56,7 +59,8 @@ defmodule SymphonyElixir.Codex.AppServer do
            turn_sandbox_policy: session_policies.turn_sandbox_policy,
            thread_id: thread_id,
            workspace: expanded_workspace,
-           worker_host: worker_host
+           worker_host: worker_host,
+           dynamic_tool_binding: dynamic_tool_binding
          }}
       else
         {:error, reason} ->
@@ -75,7 +79,8 @@ defmodule SymphonyElixir.Codex.AppServer do
           auto_approve_requests: auto_approve_requests,
           turn_sandbox_policy: turn_sandbox_policy,
           thread_id: thread_id,
-          workspace: workspace
+          workspace: workspace,
+          dynamic_tool_binding: dynamic_tool_binding
         },
         prompt,
         issue,
@@ -85,7 +90,7 @@ defmodule SymphonyElixir.Codex.AppServer do
 
     tool_executor =
       Keyword.get(opts, :tool_executor, fn tool, arguments ->
-        DynamicTool.execute(tool, arguments)
+        DynamicTool.execute(tool, arguments, binding: dynamic_tool_binding, issue: issue)
       end)
 
     case start_turn(port, thread_id, prompt, issue, workspace, approval_policy, turn_sandbox_policy) do
@@ -186,7 +191,7 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp start_port(workspace, nil) do
+  defp start_port(workspace, nil, dynamic_tool_binding) do
     executable = System.find_executable("bash")
 
     if is_nil(executable) do
@@ -201,6 +206,7 @@ defmodule SymphonyElixir.Codex.AppServer do
             :stderr_to_stdout,
             args: [~c"-lc", String.to_charlist(Config.settings!().codex.command)],
             cd: String.to_charlist(workspace),
+            env: tracker_secret_port_env(dynamic_tool_binding),
             line: @port_line_bytes
           ]
         )
@@ -209,17 +215,38 @@ defmodule SymphonyElixir.Codex.AppServer do
     end
   end
 
-  defp start_port(workspace, worker_host) when is_binary(worker_host) do
-    remote_command = remote_launch_command(workspace)
+  defp start_port(workspace, worker_host, dynamic_tool_binding) when is_binary(worker_host) do
+    remote_command = remote_launch_command(workspace, dynamic_tool_binding)
     SSH.start_port(worker_host, remote_command, line: @port_line_bytes)
   end
 
-  defp remote_launch_command(workspace) when is_binary(workspace) do
+  defp remote_launch_command(workspace, dynamic_tool_binding) when is_binary(workspace) do
     [
       "cd #{shell_escape(workspace)}",
+      tracker_secret_unset_command(dynamic_tool_binding),
       "exec #{Config.settings!().codex.command}"
     ]
+    |> Enum.reject(&is_nil/1)
     |> Enum.join(" && ")
+  end
+
+  defp tracker_secret_port_env(dynamic_tool_binding) do
+    dynamic_tool_binding.secret_environment_names
+    |> valid_environment_names()
+    |> Enum.map(fn name -> {String.to_charlist(name), false} end)
+  end
+
+  defp tracker_secret_unset_command(dynamic_tool_binding) do
+    case dynamic_tool_binding.secret_environment_names |> valid_environment_names() do
+      [] -> nil
+      names -> "unset " <> Enum.join(names, " ")
+    end
+  end
+
+  defp valid_environment_names(names) do
+    Enum.filter(names, fn name ->
+      is_binary(name) and String.match?(name, ~r/^[A-Za-z_][A-Za-z0-9_]*$/)
+    end)
   end
 
   defp port_metadata(port, worker_host) when is_port(port) do
@@ -270,14 +297,19 @@ defmodule SymphonyElixir.Codex.AppServer do
     Config.codex_runtime_settings(workspace, remote: true)
   end
 
-  defp do_start_session(port, workspace, session_policies) do
+  defp do_start_session(port, workspace, session_policies, dynamic_tool_binding) do
     case send_initialize(port) do
-      :ok -> start_thread(port, workspace, session_policies)
+      :ok -> start_thread(port, workspace, session_policies, dynamic_tool_binding)
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp start_thread(port, workspace, %{approval_policy: approval_policy, thread_sandbox: thread_sandbox}) do
+  defp start_thread(
+         port,
+         workspace,
+         %{approval_policy: approval_policy, thread_sandbox: thread_sandbox},
+         dynamic_tool_binding
+       ) do
     send_message(port, %{
       "method" => "thread/start",
       "id" => @thread_start_id,
@@ -285,7 +317,7 @@ defmodule SymphonyElixir.Codex.AppServer do
         "approvalPolicy" => approval_policy,
         "sandbox" => thread_sandbox,
         "cwd" => workspace,
-        "dynamicTools" => DynamicTool.tool_specs()
+        "dynamicTools" => dynamic_tool_binding.tool_specs
       }
     })
 

--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -90,7 +90,7 @@ defmodule SymphonyElixir.Codex.AppServer do
 
     tool_executor =
       Keyword.get(opts, :tool_executor, fn tool, arguments ->
-        DynamicTool.execute(tool, arguments, binding: dynamic_tool_binding, issue: issue)
+        DynamicTool.execute(tool, arguments, dynamic_tool_binding, issue: issue)
       end)
 
     case start_turn(port, thread_id, prompt, issue, workspace, approval_policy, turn_sandbox_policy) do
@@ -204,7 +204,7 @@ defmodule SymphonyElixir.Codex.AppServer do
             :binary,
             :exit_status,
             :stderr_to_stdout,
-            args: [~c"-lc", String.to_charlist(Config.settings!().codex.command)],
+            args: [~c"-lc", String.to_charlist(local_launch_command(dynamic_tool_binding))],
             cd: String.to_charlist(workspace),
             env: tracker_secret_port_env(dynamic_tool_binding),
             line: @port_line_bytes
@@ -218,6 +218,15 @@ defmodule SymphonyElixir.Codex.AppServer do
   defp start_port(workspace, worker_host, dynamic_tool_binding) when is_binary(worker_host) do
     remote_command = remote_launch_command(workspace, dynamic_tool_binding)
     SSH.start_port(worker_host, remote_command, line: @port_line_bytes)
+  end
+
+  defp local_launch_command(dynamic_tool_binding) do
+    [
+      tracker_secret_unset_command(dynamic_tool_binding),
+      "exec #{Config.settings!().codex.command}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" && ")
   end
 
   defp remote_launch_command(workspace, dynamic_tool_binding) when is_binary(workspace) do

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -1,209 +1,25 @@
 defmodule SymphonyElixir.Codex.DynamicTool do
   @moduledoc """
-  Executes client-side tool calls requested by Codex app-server turns.
+  Dispatches client-side tool calls to the configured tracker adapter.
   """
 
-  alias SymphonyElixir.Linear.Client
-
-  @linear_graphql_tool "linear_graphql"
-  @linear_graphql_description """
-  Execute a raw GraphQL query or mutation against Linear using Symphony's configured auth.
-  """
-  @linear_graphql_input_schema %{
-    "type" => "object",
-    "additionalProperties" => false,
-    "required" => ["query"],
-    "properties" => %{
-      "query" => %{
-        "type" => "string",
-        "description" => "GraphQL query or mutation document to execute against Linear."
-      },
-      "variables" => %{
-        "type" => ["object", "null"],
-        "description" => "Optional GraphQL variables object.",
-        "additionalProperties" => true
-      }
-    }
-  }
+  alias SymphonyElixir.Tracker
 
   @spec execute(String.t() | nil, term(), keyword()) :: map()
   def execute(tool, arguments, opts \\ []) do
-    case tool do
-      @linear_graphql_tool ->
-        execute_linear_graphql(arguments, opts)
-
-      other ->
-        failure_response(%{
-          "error" => %{
-            "message" => "Unsupported dynamic tool: #{inspect(other)}.",
-            "supportedTools" => supported_tool_names()
-          }
-        })
+    case Keyword.pop(opts, :binding) do
+      {nil, opts} -> Tracker.execute_agent_tool(tool, arguments, opts)
+      {binding, opts} -> Tracker.execute_bound_agent_tool(binding, tool, arguments, opts)
     end
   end
 
   @spec tool_specs() :: [map()]
   def tool_specs do
-    [
-      %{
-        "name" => @linear_graphql_tool,
-        "description" => @linear_graphql_description,
-        "inputSchema" => @linear_graphql_input_schema
-      }
-    ]
+    Tracker.agent_tool_specs()
   end
 
-  defp execute_linear_graphql(arguments, opts) do
-    linear_client = Keyword.get(opts, :linear_client, &Client.graphql/3)
-
-    with {:ok, query, variables} <- normalize_linear_graphql_arguments(arguments),
-         {:ok, response} <- linear_client.(query, variables, []) do
-      graphql_response(response)
-    else
-      {:error, reason} ->
-        failure_response(tool_error_payload(reason))
-    end
-  end
-
-  defp normalize_linear_graphql_arguments(arguments) when is_binary(arguments) do
-    case String.trim(arguments) do
-      "" -> {:error, :missing_query}
-      query -> {:ok, query, %{}}
-    end
-  end
-
-  defp normalize_linear_graphql_arguments(arguments) when is_map(arguments) do
-    case normalize_query(arguments) do
-      {:ok, query} ->
-        case normalize_variables(arguments) do
-          {:ok, variables} ->
-            {:ok, query, variables}
-
-          {:error, reason} ->
-            {:error, reason}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp normalize_linear_graphql_arguments(_arguments), do: {:error, :invalid_arguments}
-
-  defp normalize_query(arguments) do
-    case Map.get(arguments, "query") || Map.get(arguments, :query) do
-      query when is_binary(query) ->
-        case String.trim(query) do
-          "" -> {:error, :missing_query}
-          trimmed -> {:ok, trimmed}
-        end
-
-      _ ->
-        {:error, :missing_query}
-    end
-  end
-
-  defp normalize_variables(arguments) do
-    case Map.get(arguments, "variables") || Map.get(arguments, :variables) || %{} do
-      variables when is_map(variables) -> {:ok, variables}
-      _ -> {:error, :invalid_variables}
-    end
-  end
-
-  defp graphql_response(response) do
-    success =
-      case response do
-        %{"errors" => errors} when is_list(errors) and errors != [] -> false
-        %{errors: errors} when is_list(errors) and errors != [] -> false
-        _ -> true
-      end
-
-    dynamic_tool_response(success, encode_payload(response))
-  end
-
-  defp failure_response(payload) do
-    dynamic_tool_response(false, encode_payload(payload))
-  end
-
-  defp dynamic_tool_response(success, output) when is_boolean(success) and is_binary(output) do
-    %{
-      "success" => success,
-      "output" => output,
-      "contentItems" => [
-        %{
-          "type" => "inputText",
-          "text" => output
-        }
-      ]
-    }
-  end
-
-  defp encode_payload(payload) when is_map(payload) or is_list(payload) do
-    Jason.encode!(payload, pretty: true)
-  end
-
-  defp encode_payload(payload), do: inspect(payload)
-
-  defp tool_error_payload(:missing_query) do
-    %{
-      "error" => %{
-        "message" => "`linear_graphql` requires a non-empty `query` string."
-      }
-    }
-  end
-
-  defp tool_error_payload(:invalid_arguments) do
-    %{
-      "error" => %{
-        "message" => "`linear_graphql` expects either a GraphQL query string or an object with `query` and optional `variables`."
-      }
-    }
-  end
-
-  defp tool_error_payload(:invalid_variables) do
-    %{
-      "error" => %{
-        "message" => "`linear_graphql.variables` must be a JSON object when provided."
-      }
-    }
-  end
-
-  defp tool_error_payload(:missing_linear_api_token) do
-    %{
-      "error" => %{
-        "message" => "Symphony is missing Linear auth. Set `linear.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
-      }
-    }
-  end
-
-  defp tool_error_payload({:linear_api_status, status}) do
-    %{
-      "error" => %{
-        "message" => "Linear GraphQL request failed with HTTP #{status}.",
-        "status" => status
-      }
-    }
-  end
-
-  defp tool_error_payload({:linear_api_request, reason}) do
-    %{
-      "error" => %{
-        "message" => "Linear GraphQL request failed before receiving a successful response.",
-        "reason" => inspect(reason)
-      }
-    }
-  end
-
-  defp tool_error_payload(reason) do
-    %{
-      "error" => %{
-        "message" => "Linear GraphQL tool execution failed.",
-        "reason" => inspect(reason)
-      }
-    }
-  end
-
-  defp supported_tool_names do
-    Enum.map(tool_specs(), & &1["name"])
+  @spec bind() :: map()
+  def bind do
+    Tracker.bind_agent_tools()
   end
 end

--- a/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/codex/dynamic_tool.ex
@@ -5,17 +5,9 @@ defmodule SymphonyElixir.Codex.DynamicTool do
 
   alias SymphonyElixir.Tracker
 
-  @spec execute(String.t() | nil, term(), keyword()) :: map()
-  def execute(tool, arguments, opts \\ []) do
-    case Keyword.pop(opts, :binding) do
-      {nil, opts} -> Tracker.execute_agent_tool(tool, arguments, opts)
-      {binding, opts} -> Tracker.execute_bound_agent_tool(binding, tool, arguments, opts)
-    end
-  end
-
-  @spec tool_specs() :: [map()]
-  def tool_specs do
-    Tracker.agent_tool_specs()
+  @spec execute(String.t() | nil, term(), map(), keyword()) :: map()
+  def execute(tool, arguments, binding, opts \\ []) do
+    Tracker.execute_bound_agent_tool(binding, tool, arguments, opts)
   end
 
   @spec bind() :: map()

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -3,11 +3,11 @@ defmodule SymphonyElixir.Config do
   Runtime configuration loaded from `WORKFLOW.md`.
   """
 
-  alias SymphonyElixir.Config.Schema
+  alias SymphonyElixir.{Config.Schema, Tracker}
   alias SymphonyElixir.{Workflow, WorkflowStore}
 
   @default_prompt_template """
-  You are working on a Linear issue.
+  You are working on an issue from the configured tracker.
 
   Identifier: {{ issue.identifier }}
   Title: {{ issue.title }}
@@ -109,26 +109,12 @@ defmodule SymphonyElixir.Config do
   @doc false
   @spec validate_settings(Schema.t()) :: :ok | {:error, term()}
   def validate_settings(settings) do
-    cond do
-      is_nil(settings.tracker.kind) ->
-        {:error, :missing_tracker_kind}
-
-      settings.tracker.kind not in ["linear", "memory"] ->
-        {:error, {:unsupported_tracker_kind, settings.tracker.kind}}
-
-      settings.tracker.kind == "linear" and not present_string?(settings.tracker.api_key) ->
-        {:error, :missing_linear_api_token}
-
-      settings.tracker.kind == "linear" and not present_string?(settings.tracker.project_slug) ->
-        {:error, :missing_linear_project_slug}
-
-      true ->
-        :ok
+    if is_nil(settings.tracker.kind) do
+      {:error, :missing_tracker_kind}
+    else
+      Tracker.validate_config(settings.tracker)
     end
   end
-
-  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
-  defp present_string?(_value), do: false
 
   defp format_config_error(reason) do
     case reason do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -8,6 +8,9 @@ defmodule SymphonyElixir.Config.Schema do
   alias SymphonyElixir.PathSafety
 
   @primary_key false
+  @linear_endpoint "https://api.linear.app/graphql"
+  @linear_active_states ["Todo", "In Progress"]
+  @linear_terminal_states ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"]
 
   @type t :: %__MODULE__{}
 
@@ -46,13 +49,15 @@ defmodule SymphonyElixir.Config.Schema do
 
     embedded_schema do
       field(:kind, :string)
-      field(:endpoint, :string, default: "https://api.linear.app/graphql")
+      field(:endpoint, :string)
       field(:api_key, :string)
       field(:project_slug, :string)
       field(:assignee, :string)
+      field(:provider, :map, default: %{})
+      field(:secret_environment_names, {:array, :string}, default: [])
       field(:required_labels, {:array, :string}, default: [])
-      field(:active_states, {:array, :string}, default: ["Todo", "In Progress"])
-      field(:terminal_states, {:array, :string}, default: ["Closed", "Cancelled", "Canceled", "Duplicate", "Done"])
+      field(:active_states, {:array, :string})
+      field(:terminal_states, {:array, :string})
     end
 
     @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
@@ -60,7 +65,17 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:kind, :endpoint, :api_key, :project_slug, :assignee, :required_labels, :active_states, :terminal_states],
+        [
+          :kind,
+          :endpoint,
+          :api_key,
+          :project_slug,
+          :assignee,
+          :provider,
+          :required_labels,
+          :active_states,
+          :terminal_states
+        ],
         empty_values: []
       )
       |> update_change(:required_labels, fn labels ->
@@ -332,7 +347,9 @@ defmodule SymphonyElixir.Config.Schema do
 
   @spec normalize_issue_state(String.t()) :: String.t()
   def normalize_issue_state(state_name) when is_binary(state_name) do
-    String.downcase(state_name)
+    state_name
+    |> String.trim()
+    |> String.downcase()
   end
 
   @doc false
@@ -351,7 +368,7 @@ defmodule SymphonyElixir.Config.Schema do
     validate_change(changeset, field, fn ^field, limits ->
       Enum.flat_map(limits, fn {state_name, limit} ->
         cond do
-          to_string(state_name) == "" ->
+          state_name |> to_string() |> String.trim() == "" ->
             [{field, "state names must not be blank"}]
 
           not is_integer(limit) or limit <= 0 ->
@@ -379,10 +396,55 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp finalize_settings(settings) do
+    provider = normalize_optional_map(settings.tracker.provider) || %{}
+
+    {api_key, assignee, provider, secret_environment_names} =
+      case settings.tracker.kind do
+        "linear" ->
+          linear_provider =
+            provider
+            |> Map.put_new("endpoint", settings.tracker.endpoint || @linear_endpoint)
+            |> Map.put_new("api_key", settings.tracker.api_key)
+            |> Map.put_new("project_slug", settings.tracker.project_slug)
+            |> Map.put_new("assignee", settings.tracker.assignee)
+
+          resolved_api_key =
+            resolve_secret_setting(linear_provider["api_key"], System.get_env("LINEAR_API_KEY"))
+
+          resolved_assignee =
+            resolve_secret_setting(linear_provider["assignee"], System.get_env("LINEAR_ASSIGNEE"))
+
+          {resolved_api_key, resolved_assignee,
+           linear_provider
+           |> Map.put("api_key", resolved_api_key)
+           |> Map.put("assignee", resolved_assignee), ["LINEAR_API_KEY" | env_reference_names([linear_provider["api_key"]])]}
+
+        _ ->
+          {settings.tracker.api_key, settings.tracker.assignee, provider, []}
+      end
+
+    {active_states, terminal_states} =
+      case settings.tracker.kind do
+        kind when kind in ["linear", "memory"] ->
+          {
+            settings.tracker.active_states || @linear_active_states,
+            settings.tracker.terminal_states || @linear_terminal_states
+          }
+
+        _ ->
+          {settings.tracker.active_states, settings.tracker.terminal_states}
+      end
+
     tracker = %{
       settings.tracker
-      | api_key: resolve_secret_setting(settings.tracker.api_key, System.get_env("LINEAR_API_KEY")),
-        assignee: resolve_secret_setting(settings.tracker.assignee, System.get_env("LINEAR_ASSIGNEE"))
+      | endpoint: Map.get(provider, "endpoint", settings.tracker.endpoint),
+        api_key: api_key,
+        project_slug: Map.get(provider, "project_slug", settings.tracker.project_slug),
+        assignee: assignee,
+        provider: provider,
+        secret_environment_names: Enum.uniq(secret_environment_names),
+        active_states: active_states,
+        terminal_states: terminal_states
     }
 
     workspace = %{
@@ -478,6 +540,15 @@ defmodule SymphonyElixir.Config.Schema do
   end
 
   defp env_reference_name(_value), do: :error
+
+  defp env_reference_names(values) when is_list(values) do
+    Enum.flat_map(values, fn value ->
+      case env_reference_name(value) do
+        {:ok, env_name} -> [env_name]
+        :error -> []
+      end
+    end)
+  end
 
   defp resolve_env_token(env_name) do
     case System.get_env(env_name) do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -414,10 +414,12 @@ defmodule SymphonyElixir.Config.Schema do
           resolved_assignee =
             resolve_secret_setting(linear_provider["assignee"], System.get_env("LINEAR_ASSIGNEE"))
 
-          {resolved_api_key, resolved_assignee,
-           linear_provider
-           |> Map.put("api_key", resolved_api_key)
-           |> Map.put("assignee", resolved_assignee), ["LINEAR_API_KEY" | env_reference_names([linear_provider["api_key"]])]}
+          {
+            resolved_api_key,
+            resolved_assignee,
+            linear_provider,
+            ["LINEAR_API_KEY" | env_reference_names([linear_provider["api_key"]])]
+          }
 
         _ ->
           {settings.tracker.api_key, settings.tracker.assignee, provider, []}
@@ -496,6 +498,8 @@ defmodule SymphonyElixir.Config.Schema do
       resolved -> resolved
     end
   end
+
+  defp resolve_secret_setting(value, _fallback), do: value
 
   defp resolve_path_value(value, default) when is_binary(value) do
     case normalize_path_token(value) do

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -11,9 +11,20 @@ defmodule SymphonyElixir.Linear.Adapter do
   @spec validate_config(map()) :: :ok | {:error, term()}
   def validate_config(tracker_settings) do
     cond do
-      not present_string?(tracker_settings.api_key) -> {:error, :missing_linear_api_token}
-      not present_string?(tracker_settings.project_slug) -> {:error, :missing_linear_project_slug}
-      true -> :ok
+      not present_string?(tracker_settings.endpoint) ->
+        {:error, :invalid_linear_endpoint}
+
+      not present_string?(tracker_settings.api_key) ->
+        {:error, :missing_linear_api_token}
+
+      not present_string?(tracker_settings.project_slug) ->
+        {:error, :missing_linear_project_slug}
+
+      not is_nil(tracker_settings.assignee) and not present_string?(tracker_settings.assignee) ->
+        {:error, :invalid_linear_assignee}
+
+      true ->
+        :ok
     end
   end
 

--- a/elixir/lib/symphony_elixir/linear/adapter.ex
+++ b/elixir/lib/symphony_elixir/linear/adapter.ex
@@ -5,87 +5,39 @@ defmodule SymphonyElixir.Linear.Adapter do
 
   @behaviour SymphonyElixir.Tracker
 
-  alias SymphonyElixir.Linear.Client
+  alias SymphonyElixir.Linear.{AgentTool, Client}
+  alias SymphonyElixir.Tracker.Issue
 
-  @create_comment_mutation """
-  mutation SymphonyCreateComment($issueId: String!, $body: String!) {
-    commentCreate(input: {issueId: $issueId, body: $body}) {
-      success
-    }
-  }
-  """
+  @spec validate_config(map()) :: :ok | {:error, term()}
+  def validate_config(tracker_settings) do
+    cond do
+      not present_string?(tracker_settings.api_key) -> {:error, :missing_linear_api_token}
+      not present_string?(tracker_settings.project_slug) -> {:error, :missing_linear_project_slug}
+      true -> :ok
+    end
+  end
 
-  @update_state_mutation """
-  mutation SymphonyUpdateIssueState($issueId: String!, $stateId: String!) {
-    issueUpdate(id: $issueId, input: {stateId: $stateId}) {
-      success
-    }
-  }
-  """
-
-  @state_lookup_query """
-  query SymphonyResolveStateId($issueId: String!, $stateName: String!) {
-    issue(id: $issueId) {
-      team {
-        states(filter: {name: {eq: $stateName}}, first: 1) {
-          nodes {
-            id
-          }
-        }
-      }
-    }
-  }
-  """
-
-  @spec fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
-  def fetch_candidate_issues, do: client_module().fetch_candidate_issues()
-
-  @spec fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issues_by_states(states), do: client_module().fetch_issues_by_states(states)
 
-  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
-  def fetch_issue_states_by_ids(issue_ids), do: client_module().fetch_issue_states_by_ids(issue_ids)
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(issue_ids), do: client_module().fetch_issues_by_ids(issue_ids)
 
-  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
-  def create_comment(issue_id, body) when is_binary(issue_id) and is_binary(body) do
-    with {:ok, response} <- client_module().graphql(@create_comment_mutation, %{issueId: issue_id, body: body}),
-         true <- get_in(response, ["data", "commentCreate", "success"]) == true do
-      :ok
-    else
-      false -> {:error, :comment_create_failed}
-      {:error, reason} -> {:error, reason}
-      _ -> {:error, :comment_create_failed}
-    end
+  @spec agent_tool_specs() :: [map()]
+  def agent_tool_specs, do: AgentTool.tool_specs()
+
+  @spec execute_agent_tool(String.t(), term(), keyword()) :: map()
+  def execute_agent_tool(tool, arguments, opts) do
+    AgentTool.execute(tool, arguments, opts)
   end
 
-  @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
-  def update_issue_state(issue_id, state_name)
-      when is_binary(issue_id) and is_binary(state_name) do
-    with {:ok, state_id} <- resolve_state_id(issue_id, state_name),
-         {:ok, response} <-
-           client_module().graphql(@update_state_mutation, %{issueId: issue_id, stateId: state_id}),
-         true <- get_in(response, ["data", "issueUpdate", "success"]) == true do
-      :ok
-    else
-      false -> {:error, :issue_update_failed}
-      {:error, reason} -> {:error, reason}
-      _ -> {:error, :issue_update_failed}
-    end
-  end
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(tracker_settings), do: tracker_settings.secret_environment_names
 
   defp client_module do
     Application.get_env(:symphony_elixir, :linear_client_module, Client)
   end
 
-  defp resolve_state_id(issue_id, state_name) do
-    with {:ok, response} <-
-           client_module().graphql(@state_lookup_query, %{issueId: issue_id, stateName: state_name}),
-         state_id when is_binary(state_id) <-
-           get_in(response, ["data", "issue", "team", "states", "nodes", Access.at(0), "id"]) do
-      {:ok, state_id}
-    else
-      {:error, reason} -> {:error, reason}
-      _ -> {:error, :state_not_found}
-    end
-  end
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
 end

--- a/elixir/lib/symphony_elixir/linear/agent_tool.ex
+++ b/elixir/lib/symphony_elixir/linear/agent_tool.ex
@@ -1,0 +1,210 @@
+defmodule SymphonyElixir.Linear.AgentTool do
+  @moduledoc """
+  Provider-native Linear tool exposed to Codex app-server turns.
+  """
+
+  alias SymphonyElixir.Linear.Client
+
+  @linear_graphql_tool "linear_graphql"
+  @linear_graphql_description """
+  Execute a raw GraphQL query or mutation against Linear using Symphony's configured auth.
+  """
+  @linear_graphql_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["query"],
+    "properties" => %{
+      "query" => %{
+        "type" => "string",
+        "description" => "GraphQL query or mutation document to execute against Linear."
+      },
+      "variables" => %{
+        "type" => ["object", "null"],
+        "description" => "Optional GraphQL variables object.",
+        "additionalProperties" => true
+      }
+    }
+  }
+
+  @spec execute(String.t() | nil, term(), keyword()) :: map()
+  def execute(tool, arguments, opts) do
+    case tool do
+      @linear_graphql_tool ->
+        execute_linear_graphql(arguments, opts)
+
+      other ->
+        failure_response(%{
+          "error" => %{
+            "message" => "Unsupported dynamic tool: #{inspect(other)}.",
+            "supportedTools" => supported_tool_names()
+          }
+        })
+    end
+  end
+
+  @spec tool_specs() :: [map()]
+  def tool_specs do
+    [
+      %{
+        "name" => @linear_graphql_tool,
+        "description" => @linear_graphql_description,
+        "inputSchema" => @linear_graphql_input_schema
+      }
+    ]
+  end
+
+  defp execute_linear_graphql(arguments, opts) do
+    linear_client = Keyword.get(opts, :linear_client, &Client.graphql/3)
+    client_opts = Keyword.take(opts, [:tracker_settings])
+
+    with {:ok, query, variables} <- normalize_linear_graphql_arguments(arguments),
+         {:ok, response} <- linear_client.(query, variables, client_opts) do
+      graphql_response(response)
+    else
+      {:error, reason} ->
+        failure_response(tool_error_payload(reason))
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(arguments) when is_binary(arguments) do
+    case String.trim(arguments) do
+      "" -> {:error, :missing_query}
+      query -> {:ok, query, %{}}
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(arguments) when is_map(arguments) do
+    case normalize_query(arguments) do
+      {:ok, query} ->
+        case normalize_variables(arguments) do
+          {:ok, variables} ->
+            {:ok, query, variables}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(_arguments), do: {:error, :invalid_arguments}
+
+  defp normalize_query(arguments) do
+    case Map.get(arguments, "query") || Map.get(arguments, :query) do
+      query when is_binary(query) ->
+        case String.trim(query) do
+          "" -> {:error, :missing_query}
+          trimmed -> {:ok, trimmed}
+        end
+
+      _ ->
+        {:error, :missing_query}
+    end
+  end
+
+  defp normalize_variables(arguments) do
+    case Map.get(arguments, "variables") || Map.get(arguments, :variables) || %{} do
+      variables when is_map(variables) -> {:ok, variables}
+      _ -> {:error, :invalid_variables}
+    end
+  end
+
+  defp graphql_response(response) do
+    success =
+      case response do
+        %{"errors" => errors} when is_list(errors) and errors != [] -> false
+        %{errors: errors} when is_list(errors) and errors != [] -> false
+        _ -> true
+      end
+
+    dynamic_tool_response(success, encode_payload(response))
+  end
+
+  defp failure_response(payload) do
+    dynamic_tool_response(false, encode_payload(payload))
+  end
+
+  defp dynamic_tool_response(success, output) when is_boolean(success) and is_binary(output) do
+    %{
+      "success" => success,
+      "output" => output,
+      "contentItems" => [
+        %{
+          "type" => "inputText",
+          "text" => output
+        }
+      ]
+    }
+  end
+
+  defp encode_payload(payload) when is_map(payload) or is_list(payload) do
+    Jason.encode!(payload, pretty: true)
+  end
+
+  defp encode_payload(payload), do: inspect(payload)
+
+  defp tool_error_payload(:missing_query) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql` requires a non-empty `query` string."
+      }
+    }
+  end
+
+  defp tool_error_payload(:invalid_arguments) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql` expects either a GraphQL query string or an object with `query` and optional `variables`."
+      }
+    }
+  end
+
+  defp tool_error_payload(:invalid_variables) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql.variables` must be a JSON object when provided."
+      }
+    }
+  end
+
+  defp tool_error_payload(:missing_linear_api_token) do
+    %{
+      "error" => %{
+        "message" => "Symphony is missing Linear auth. Set `tracker.provider.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
+      }
+    }
+  end
+
+  defp tool_error_payload({:linear_api_status, status}) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL request failed with HTTP #{status}.",
+        "status" => status
+      }
+    }
+  end
+
+  defp tool_error_payload({:linear_api_request, reason}) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL request failed before receiving a successful response.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp tool_error_payload(reason) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL tool execution failed.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp supported_tool_names do
+    Enum.map(tool_specs(), & &1["name"])
+  end
+end

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -140,7 +140,7 @@ defmodule SymphonyElixir.Linear.Client do
   def graphql(query, variables \\ %{}, opts \\ [])
       when is_binary(query) and is_map(variables) and is_list(opts) do
     payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
-    tracker_settings = Keyword.get(opts, :tracker_settings, Config.settings!().tracker)
+    tracker_settings = Keyword.get_lazy(opts, :tracker_settings, fn -> Config.settings!().tracker end)
 
     request_fun =
       Keyword.get(opts, :request_fun, fn request_payload, headers ->
@@ -410,10 +410,21 @@ defmodule SymphonyElixir.Linear.Client do
       nodes
       |> Enum.map(&normalize_issue(&1, assignee_filter))
 
-    case {malformed_policy, Enum.any?(issues, &is_nil/1)} do
-      {:error_on_malformed, true} -> {:error, :linear_unknown_payload}
-      {:drop_malformed, _} -> {:ok, Enum.reject(issues, &is_nil/1)}
-      {_, false} -> {:ok, issues}
+    malformed_count = Enum.count(issues, &is_nil/1)
+
+    case {malformed_policy, malformed_count > 0} do
+      {:error_on_malformed, true} ->
+        {:error, :linear_unknown_payload}
+
+      {:drop_malformed, true} ->
+        Logger.warning("Dropping malformed Linear issue records count=#{malformed_count}")
+        {:ok, Enum.reject(issues, &is_nil/1)}
+
+      {:drop_malformed, false} ->
+        {:ok, issues}
+
+      {_, false} ->
+        {:ok, issues}
     end
   end
 

--- a/elixir/lib/symphony_elixir/linear/client.ex
+++ b/elixir/lib/symphony_elixir/linear/client.ex
@@ -4,7 +4,8 @@ defmodule SymphonyElixir.Linear.Client do
   """
 
   require Logger
-  alias SymphonyElixir.{Config, Linear.Issue}
+  alias SymphonyElixir.Config
+  alias SymphonyElixir.Tracker.Issue
 
   @issue_page_size 50
   @max_error_body_log_bytes 1_000
@@ -55,8 +56,8 @@ defmodule SymphonyElixir.Linear.Client do
   """
 
   @query_by_ids """
-  query SymphonyLinearIssuesById($ids: [ID!]!, $first: Int!, $relationFirst: Int!) {
-    issues(filter: {id: {in: $ids}}, first: $first) {
+  query SymphonyLinearIssuesById($ids: [ID!]!, $projectSlug: String!, $first: Int!, $relationFirst: Int!) {
+    issues(filter: {id: {in: $ids}, project: {slugId: {eq: $projectSlug}}}, first: $first) {
       nodes {
         id
         identifier
@@ -103,50 +104,24 @@ defmodule SymphonyElixir.Linear.Client do
   }
   """
 
-  @spec fetch_candidate_issues() :: {:ok, [Issue.t()]} | {:error, term()}
-  def fetch_candidate_issues do
-    tracker = Config.settings!().tracker
-    project_slug = tracker.project_slug
-
-    cond do
-      is_nil(tracker.api_key) ->
-        {:error, :missing_linear_api_token}
-
-      is_nil(project_slug) ->
-        {:error, :missing_linear_project_slug}
-
-      true ->
-        with {:ok, assignee_filter} <- routing_assignee_filter() do
-          do_fetch_by_states(project_slug, tracker.active_states, assignee_filter)
-        end
-    end
-  end
-
   @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issues_by_states(state_names) when is_list(state_names) do
     normalized_states = Enum.map(state_names, &to_string/1) |> Enum.uniq()
 
-    if normalized_states == [] do
-      {:ok, []}
-    else
-      tracker = Config.settings!().tracker
-      project_slug = tracker.project_slug
+    case normalized_states do
+      [] ->
+        {:ok, []}
 
-      cond do
-        is_nil(tracker.api_key) ->
-          {:error, :missing_linear_api_token}
-
-        is_nil(project_slug) ->
-          {:error, :missing_linear_project_slug}
-
-        true ->
-          do_fetch_by_states(project_slug, normalized_states, nil)
-      end
+      states ->
+        with {:ok, tracker} <- configured_tracker_for_read(),
+             {:ok, assignee_filter} <- routing_assignee_filter() do
+          do_fetch_by_states(tracker.project_slug, states, assignee_filter)
+        end
     end
   end
 
-  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
-  def fetch_issue_states_by_ids(issue_ids) when is_list(issue_ids) do
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(issue_ids) when is_list(issue_ids) do
     ids = Enum.uniq(issue_ids)
 
     case ids do
@@ -154,8 +129,9 @@ defmodule SymphonyElixir.Linear.Client do
         {:ok, []}
 
       ids ->
-        with {:ok, assignee_filter} <- routing_assignee_filter() do
-          do_fetch_issue_states(ids, assignee_filter)
+        with {:ok, tracker} <- configured_tracker_for_read(),
+             {:ok, assignee_filter} <- routing_assignee_filter() do
+          do_fetch_issue_states(ids, tracker.project_slug, assignee_filter)
         end
     end
   end
@@ -164,9 +140,14 @@ defmodule SymphonyElixir.Linear.Client do
   def graphql(query, variables \\ %{}, opts \\ [])
       when is_binary(query) and is_map(variables) and is_list(opts) do
     payload = build_graphql_payload(query, variables, Keyword.get(opts, :operation_name))
-    request_fun = Keyword.get(opts, :request_fun, &post_graphql_request/2)
+    tracker_settings = Keyword.get(opts, :tracker_settings, Config.settings!().tracker)
 
-    with {:ok, headers} <- graphql_headers(),
+    request_fun =
+      Keyword.get(opts, :request_fun, fn request_payload, headers ->
+        post_graphql_request(request_payload, headers, tracker_settings.endpoint)
+      end)
+
+    with {:ok, headers} <- graphql_headers(tracker_settings),
          {:ok, %{status: 200, body: body}} <- request_fun.(payload, headers) do
       {:ok, body}
     else
@@ -221,9 +202,9 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   @doc false
-  @spec fetch_issue_states_by_ids_for_test([String.t()], (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
+  @spec fetch_issues_by_ids_for_test([String.t()], (String.t(), map() -> {:ok, map()} | {:error, term()})) ::
           {:ok, [Issue.t()]} | {:error, term()}
-  def fetch_issue_states_by_ids_for_test(issue_ids, graphql_fun)
+  def fetch_issues_by_ids_for_test(issue_ids, graphql_fun)
       when is_list(issue_ids) and is_function(graphql_fun, 2) do
     ids = Enum.uniq(issue_ids)
 
@@ -232,7 +213,7 @@ defmodule SymphonyElixir.Linear.Client do
         {:ok, []}
 
       ids ->
-        do_fetch_issue_states(ids, nil, graphql_fun)
+        do_fetch_issue_states(ids, "test-project", nil, graphql_fun)
     end
   end
 
@@ -271,35 +252,44 @@ defmodule SymphonyElixir.Linear.Client do
 
   defp finalize_paginated_issues(acc_issues) when is_list(acc_issues), do: Enum.reverse(acc_issues)
 
-  defp do_fetch_issue_states(ids, assignee_filter) do
-    do_fetch_issue_states(ids, assignee_filter, &graphql/2)
+  defp do_fetch_issue_states(ids, project_slug, assignee_filter) do
+    do_fetch_issue_states(ids, project_slug, assignee_filter, &graphql/2)
   end
 
-  defp do_fetch_issue_states(ids, assignee_filter, graphql_fun)
-       when is_list(ids) and is_function(graphql_fun, 2) do
+  defp do_fetch_issue_states(ids, project_slug, assignee_filter, graphql_fun)
+       when is_list(ids) and is_binary(project_slug) and is_function(graphql_fun, 2) do
     issue_order_index = issue_order_index(ids)
-    do_fetch_issue_states_page(ids, assignee_filter, graphql_fun, [], issue_order_index)
+    do_fetch_issue_states_page(ids, project_slug, assignee_filter, graphql_fun, [], issue_order_index)
   end
 
-  defp do_fetch_issue_states_page([], _assignee_filter, _graphql_fun, acc_issues, issue_order_index) do
+  defp do_fetch_issue_states_page([], _project_slug, _assignee_filter, _graphql_fun, acc_issues, issue_order_index) do
     acc_issues
     |> finalize_paginated_issues()
     |> sort_issues_by_requested_ids(issue_order_index)
     |> then(&{:ok, &1})
   end
 
-  defp do_fetch_issue_states_page(ids, assignee_filter, graphql_fun, acc_issues, issue_order_index) do
+  defp do_fetch_issue_states_page(ids, project_slug, assignee_filter, graphql_fun, acc_issues, issue_order_index) do
     {batch_ids, rest_ids} = Enum.split(ids, @issue_page_size)
 
     case graphql_fun.(@query_by_ids, %{
            ids: batch_ids,
+           projectSlug: project_slug,
            first: length(batch_ids),
            relationFirst: @issue_page_size
          }) do
       {:ok, body} ->
-        with {:ok, issues} <- decode_linear_response(body, assignee_filter) do
+        with {:ok, issues} <- decode_linear_response_strict(body, assignee_filter) do
           updated_acc = prepend_page_issues(issues, acc_issues)
-          do_fetch_issue_states_page(rest_ids, assignee_filter, graphql_fun, updated_acc, issue_order_index)
+
+          do_fetch_issue_states_page(
+            rest_ids,
+            project_slug,
+            assignee_filter,
+            graphql_fun,
+            updated_acc,
+            issue_order_index
+          )
         end
 
       {:error, reason} ->
@@ -380,8 +370,8 @@ defmodule SymphonyElixir.Linear.Client do
     end
   end
 
-  defp graphql_headers do
-    case Config.settings!().tracker.api_key do
+  defp graphql_headers(tracker_settings) do
+    case tracker_settings.api_key do
       nil ->
         {:error, :missing_linear_api_token}
 
@@ -394,28 +384,44 @@ defmodule SymphonyElixir.Linear.Client do
     end
   end
 
-  defp post_graphql_request(payload, headers) do
-    Req.post(Config.settings!().tracker.endpoint,
+  defp post_graphql_request(payload, headers, endpoint) do
+    Req.post(endpoint,
       headers: headers,
       json: payload,
       connect_options: [timeout: 30_000]
     )
   end
 
-  defp decode_linear_response(%{"data" => %{"issues" => %{"nodes" => nodes}}}, assignee_filter) do
+  defp decode_linear_response(response, assignee_filter) do
+    decode_linear_response(response, assignee_filter, :drop_malformed)
+  end
+
+  defp decode_linear_response_strict(response, assignee_filter) do
+    decode_linear_response(response, assignee_filter, :error_on_malformed)
+  end
+
+  defp decode_linear_response(
+         %{"data" => %{"issues" => %{"nodes" => nodes}}},
+         assignee_filter,
+         malformed_policy
+       )
+       when is_list(nodes) do
     issues =
       nodes
       |> Enum.map(&normalize_issue(&1, assignee_filter))
-      |> Enum.reject(&is_nil(&1))
 
-    {:ok, issues}
+    case {malformed_policy, Enum.any?(issues, &is_nil/1)} do
+      {:error_on_malformed, true} -> {:error, :linear_unknown_payload}
+      {:drop_malformed, _} -> {:ok, Enum.reject(issues, &is_nil/1)}
+      {_, false} -> {:ok, issues}
+    end
   end
 
-  defp decode_linear_response(%{"errors" => errors}, _assignee_filter) do
+  defp decode_linear_response(%{"errors" => errors}, _assignee_filter, _malformed_policy) do
     {:error, {:linear_graphql_errors, errors}}
   end
 
-  defp decode_linear_response(_unknown, _assignee_filter) do
+  defp decode_linear_response(_unknown, _assignee_filter, _malformed_policy) do
     {:error, :linear_unknown_payload}
   end
 
@@ -446,30 +452,69 @@ defmodule SymphonyElixir.Linear.Client do
   defp next_page_cursor(_), do: :done
 
   defp normalize_issue(issue, assignee_filter) when is_map(issue) do
-    assignee = issue["assignee"]
+    state_name = get_in(issue, ["state", "name"])
 
-    %Issue{
-      id: issue["id"],
-      identifier: issue["identifier"],
-      title: issue["title"],
-      description: issue["description"],
-      priority: parse_priority(issue["priority"]),
-      state: get_in(issue, ["state", "name"]),
-      branch_name: issue["branchName"],
-      url: issue["url"],
-      assignee_id: assignee_field(assignee, "id"),
-      blocked_by: extract_blockers(issue),
-      labels: extract_labels(issue),
-      assigned_to_worker: assigned_to_worker?(assignee, assignee_filter),
-      created_at: parse_datetime(issue["createdAt"]),
-      updated_at: parse_datetime(issue["updatedAt"])
-    }
+    if Enum.all?([issue["id"], issue["identifier"], issue["title"], state_name], &present_string?/1) do
+      assignee = issue["assignee"]
+      blockers = extract_blockers(issue)
+
+      %Issue{
+        id: issue["id"],
+        identifier: issue["identifier"],
+        title: issue["title"],
+        description: issue["description"],
+        priority: parse_priority(issue["priority"]),
+        state: state_name,
+        branch_name: issue["branchName"],
+        url: issue["url"],
+        assignee_id: assignee_field(assignee, "id"),
+        blocked_by: blockers,
+        labels: extract_labels(issue),
+        dispatchable: dispatchable?(state_name, blockers, assignee, assignee_filter),
+        created_at: parse_datetime(issue["createdAt"]),
+        updated_at: parse_datetime(issue["updatedAt"])
+      }
+    end
   end
 
   defp normalize_issue(_issue, _assignee_filter), do: nil
 
   defp assignee_field(%{} = assignee, field) when is_binary(field), do: assignee[field]
   defp assignee_field(_assignee, _field), do: nil
+
+  defp dispatchable?(state_name, blockers, assignee, assignee_filter) do
+    assigned_to_worker?(assignee, assignee_filter) and
+      not blocked_before_dispatch?(state_name, blockers)
+  end
+
+  defp blocked_before_dispatch?(state_name, blockers)
+       when is_binary(state_name) and is_list(blockers) do
+    normalize_state_name(state_name) == "todo" and
+      Enum.any?(blockers, fn
+        %{state: blocker_state} when is_binary(blocker_state) ->
+          not terminal_state?(blocker_state)
+
+        _ ->
+          true
+      end)
+  end
+
+  defp blocked_before_dispatch?(_state_name, _blockers), do: false
+
+  defp terminal_state?(state_name) when is_binary(state_name) do
+    terminal_states =
+      Config.settings!().tracker.terminal_states
+      |> Enum.map(&normalize_state_name/1)
+      |> MapSet.new()
+
+    MapSet.member?(terminal_states, normalize_state_name(state_name))
+  end
+
+  defp normalize_state_name(state_name) when is_binary(state_name) do
+    state_name
+    |> String.trim()
+    |> String.downcase()
+  end
 
   defp assigned_to_worker?(_assignee, nil), do: true
 
@@ -494,6 +539,16 @@ defmodule SymphonyElixir.Linear.Client do
 
       assignee ->
         build_assignee_filter(assignee)
+    end
+  end
+
+  defp configured_tracker_for_read do
+    tracker = Config.settings!().tracker
+
+    cond do
+      is_nil(tracker.api_key) -> {:error, :missing_linear_api_token}
+      is_nil(tracker.project_slug) -> {:error, :missing_linear_project_slug}
+      true -> {:ok, tracker}
     end
   end
 
@@ -541,8 +596,10 @@ defmodule SymphonyElixir.Linear.Client do
   defp extract_labels(%{"labels" => %{"nodes" => labels}}) when is_list(labels) do
     labels
     |> Enum.map(& &1["name"])
-    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(&is_binary/1)
     |> Enum.map(&(String.trim(&1) |> String.downcase()))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
   end
 
   defp extract_labels(_), do: []
@@ -571,6 +628,9 @@ defmodule SymphonyElixir.Linear.Client do
   end
 
   defp extract_blockers(_), do: []
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
 
   defp parse_datetime(nil), do: nil
 

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Orchestrator do
   @moduledoc """
-  Polls Linear and dispatches repository copies to Codex-backed workers.
+  Polls the configured issue tracker and dispatches repository copies to Codex-backed workers.
   """
 
   use GenServer
@@ -8,7 +8,7 @@ defmodule SymphonyElixir.Orchestrator do
   import Bitwise, only: [<<<: 2]
 
   alias SymphonyElixir.{AgentRunner, Config, StatusDashboard, Tracker, Workspace}
-  alias SymphonyElixir.Linear.Issue
+  alias SymphonyElixir.Tracker.Issue
 
   @continuation_retry_delay_ms 1_000
   @failure_retry_base_ms 10_000
@@ -260,16 +260,16 @@ defmodule SymphonyElixir.Orchestrator do
       |> reconcile_blocked_issues()
 
     with :ok <- Config.validate!(),
-         {:ok, issues} <- Tracker.fetch_candidate_issues(),
+         {:ok, issues} <- Tracker.fetch_issues_by_states(Config.settings!().tracker.active_states),
          true <- available_slots(state) > 0 do
       choose_issues(issues, state)
     else
       {:error, :missing_linear_api_token} ->
-        Logger.error("Linear API token missing in WORKFLOW.md")
+        Logger.error("Tracker API token missing in WORKFLOW.md")
         state
 
       {:error, :missing_linear_project_slug} ->
-        Logger.error("Linear project slug missing in WORKFLOW.md")
+        Logger.error("Tracker project scope missing in WORKFLOW.md")
         state
 
       {:error, :missing_tracker_kind} ->
@@ -299,7 +299,7 @@ defmodule SymphonyElixir.Orchestrator do
         state
 
       {:error, reason} ->
-        Logger.error("Failed to fetch from Linear: #{inspect(reason)}")
+        Logger.error("Failed to fetch from issue tracker: #{inspect(reason)}")
         state
 
       false ->
@@ -314,7 +314,7 @@ defmodule SymphonyElixir.Orchestrator do
     if running_ids == [] do
       state
     else
-      case Tracker.fetch_issue_states_by_ids(running_ids) do
+      case Tracker.fetch_issues_by_ids(running_ids) do
         {:ok, issues} ->
           issues
           |> reconcile_running_issue_states(
@@ -338,7 +338,7 @@ defmodule SymphonyElixir.Orchestrator do
     if blocked_ids == [] do
       state
     else
-      case Tracker.fetch_issue_states_by_ids(blocked_ids) do
+      case Tracker.fetch_issues_by_ids(blocked_ids) do
         {:ok, issues} ->
           issues
           |> reconcile_blocked_issue_states(
@@ -457,7 +457,7 @@ defmodule SymphonyElixir.Orchestrator do
     cond do
       terminal_issue_state?(issue.state, terminal_states) ->
         Logger.info("Blocked issue moved to terminal state: #{issue_context(issue)} state=#{issue.state}; releasing block")
-        cleanup_issue_workspace(issue.identifier, blocked_issue_worker_host(state, issue.id))
+        cleanup_issue_workspace(issue, blocked_issue_worker_host(state, issue.id))
         release_issue_claim(state, issue.id)
 
       !issue_routable?(issue) ->
@@ -561,7 +561,7 @@ defmodule SymphonyElixir.Orchestrator do
         worker_host = Map.get(running_entry, :worker_host)
 
         if cleanup_workspace do
-          cleanup_issue_workspace(identifier, worker_host)
+          cleanup_issue_workspace(Map.get(running_entry, :issue, identifier), worker_host)
         end
 
         stop_running_task(pid, ref, state.task_supervisor)
@@ -821,7 +821,6 @@ defmodule SymphonyElixir.Orchestrator do
          terminal_states
        ) do
     candidate_issue?(issue, active_states, terminal_states) and
-      !todo_issue_blocked_by_non_terminal?(issue, terminal_states) and
       !MapSet.member?(claimed, issue.id) and
       !Map.has_key?(running, issue.id) and
       !Map.has_key?(blocked, issue.id) and
@@ -863,7 +862,8 @@ defmodule SymphonyElixir.Orchestrator do
          terminal_states
        )
        when is_binary(id) and is_binary(identifier) and is_binary(title) and is_binary(state_name) do
-    issue_routable?(issue) and
+    Enum.all?([id, identifier, title, state_name], &present_string?/1) and
+      issue_routable?(issue) and
       active_issue_state?(state_name, active_states) and
       !terminal_issue_state?(state_name, terminal_states)
   end
@@ -874,28 +874,14 @@ defmodule SymphonyElixir.Orchestrator do
     Issue.routable?(issue, Config.settings!().tracker.required_labels)
   end
 
-  defp todo_issue_blocked_by_non_terminal?(
-         %Issue{state: issue_state, blocked_by: blockers},
-         terminal_states
-       )
-       when is_binary(issue_state) and is_list(blockers) do
-    normalize_issue_state(issue_state) == "todo" and
-      Enum.any?(blockers, fn
-        %{state: blocker_state} when is_binary(blocker_state) ->
-          !terminal_issue_state?(blocker_state, terminal_states)
-
-        _ ->
-          true
-      end)
-  end
-
-  defp todo_issue_blocked_by_non_terminal?(_issue, _terminal_states), do: false
-
   defp terminal_issue_state?(state_name, terminal_states) when is_binary(state_name) do
     MapSet.member?(terminal_states, normalize_issue_state(state_name))
   end
 
   defp terminal_issue_state?(_state_name, _terminal_states), do: false
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
 
   defp active_issue_state?(state_name, active_states) when is_binary(state_name) do
     MapSet.member?(active_states, normalize_issue_state(state_name))
@@ -920,7 +906,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp dispatch_issue(%State{} = state, issue, attempt \\ nil, preferred_worker_host \\ nil) do
-    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issue_states_by_ids/1, terminal_state_set()) do
+    case revalidate_issue_for_dispatch(issue, &Tracker.fetch_issues_by_ids/1, terminal_state_set()) do
       {:ok, %Issue{} = refreshed_issue} ->
         do_dispatch_issue(state, refreshed_issue, attempt, preferred_worker_host)
 
@@ -1093,7 +1079,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp handle_retry_issue(%State{} = state, issue_id, attempt, metadata) do
-    case Tracker.fetch_candidate_issues() do
+    case Tracker.fetch_issues_by_ids([issue_id]) do
       {:ok, issues} ->
         issues
         |> find_issue_by_id(issue_id)
@@ -1119,7 +1105,7 @@ defmodule SymphonyElixir.Orchestrator do
       terminal_issue_state?(issue.state, terminal_states) ->
         Logger.info("Issue state is terminal: issue_id=#{issue_id} issue_identifier=#{issue.identifier} state=#{issue.state}; removing associated workspace")
 
-        cleanup_issue_workspace(issue.identifier, metadata[:worker_host])
+        cleanup_issue_workspace(issue, metadata[:worker_host])
         {:noreply, release_issue_claim(state, issue_id)}
 
       retry_candidate_issue?(issue, terminal_states) ->
@@ -1139,11 +1125,15 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp cleanup_issue_workspace(identifier, worker_host \\ nil)
 
+  defp cleanup_issue_workspace(%Issue{} = issue, worker_host) do
+    Workspace.remove_issue_workspaces(issue, worker_host)
+  end
+
   defp cleanup_issue_workspace(identifier, worker_host) when is_binary(identifier) do
     Workspace.remove_issue_workspaces(identifier, worker_host)
   end
 
-  defp cleanup_issue_workspace(_identifier, _worker_host), do: :ok
+  defp cleanup_issue_workspace(_issue_or_identifier, _worker_host), do: :ok
 
   defp blocked_issue_worker_host(%State{} = state, issue_id) do
     state.blocked
@@ -1156,8 +1146,8 @@ defmodule SymphonyElixir.Orchestrator do
       {:ok, issues} ->
         issues
         |> Enum.each(fn
-          %Issue{identifier: identifier} when is_binary(identifier) ->
-            cleanup_issue_workspace(identifier)
+          %Issue{} = issue ->
+            cleanup_issue_workspace(issue)
 
           _ ->
             :ok
@@ -1613,8 +1603,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp retry_candidate_issue?(%Issue{} = issue, terminal_states) do
-    candidate_issue?(issue, active_state_set(), terminal_states) and
-      !todo_issue_blocked_by_non_terminal?(issue, terminal_states)
+    candidate_issue?(issue, active_state_set(), terminal_states)
   end
 
   defp dispatch_slots_available?(%Issue{} = issue, %State{} = state) do

--- a/elixir/lib/symphony_elixir/prompt_builder.ex
+++ b/elixir/lib/symphony_elixir/prompt_builder.ex
@@ -1,13 +1,13 @@
 defmodule SymphonyElixir.PromptBuilder do
   @moduledoc """
-  Builds agent prompts from Linear issue data.
+  Builds agent prompts from normalized tracker work item data.
   """
 
   alias SymphonyElixir.{Config, Workflow}
 
   @render_opts [strict_variables: true, strict_filters: true]
 
-  @spec build_prompt(SymphonyElixir.Linear.Issue.t(), keyword()) :: String.t()
+  @spec build_prompt(SymphonyElixir.Tracker.Issue.t(), keyword()) :: String.t()
   def build_prompt(issue, opts \\ []) do
     template =
       Workflow.current()

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -394,8 +394,9 @@ defmodule SymphonyElixir.StatusDashboard do
 
   defp format_project_link_lines do
     project_part =
-      case Config.settings!().tracker.project_slug do
-        project_slug when is_binary(project_slug) and project_slug != "" ->
+      case Config.settings!().tracker do
+        %{kind: "linear", project_slug: project_slug}
+        when is_binary(project_slug) and project_slug != "" ->
           colorize(linear_project_url(project_slug), @ansi_cyan)
 
         _ ->

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -24,7 +24,6 @@ defmodule SymphonyElixir.Tracker do
 
   @optional_callbacks agent_tool_specs: 0,
                       execute_agent_tool: 3,
-                      secret_environment_names: 1,
                       validate_config: 1
 
   @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
@@ -35,26 +34,6 @@ defmodule SymphonyElixir.Tracker do
   @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issues_by_ids(issue_ids) do
     adapter().fetch_issues_by_ids(issue_ids)
-  end
-
-  @spec agent_tool_specs() :: [map()]
-  def agent_tool_specs do
-    adapter_agent_tool_specs(adapter())
-  end
-
-  @spec execute_agent_tool(String.t(), term(), keyword()) :: map()
-  def execute_agent_tool(tool, arguments, opts \\ []) do
-    execute_agent_tool_with_adapter(adapter(), tool, arguments, opts)
-  end
-
-  @doc """
-  Environment variables containing tracker credentials that must not be
-  inherited by the Codex child process.
-  """
-  @spec secret_environment_names() :: [String.t()]
-  def secret_environment_names do
-    tracker_settings = Config.settings!().tracker
-    adapter_secret_environment_names(adapter_for_settings!(tracker_settings), tracker_settings)
   end
 
   @doc """
@@ -137,11 +116,7 @@ defmodule SymphonyElixir.Tracker do
   end
 
   defp adapter_secret_environment_names(adapter, tracker_settings) do
-    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :secret_environment_names, 1) do
-      adapter.secret_environment_names(tracker_settings)
-    else
-      []
-    end
+    adapter.secret_environment_names(tracker_settings)
   end
 
   defp unsupported_agent_tool_response(tool) do

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -1,46 +1,162 @@
 defmodule SymphonyElixir.Tracker do
   @moduledoc """
-  Adapter boundary for issue tracker reads and writes.
+  Adapter boundary for issue tracker reads and provider-native agent tools.
+
+  The orchestrator only depends on the read callbacks. Agent-side mutations stay
+  behind optional provider-native tools so tracker-specific capabilities do not
+  leak into scheduler policy.
   """
 
   alias SymphonyElixir.Config
+  alias SymphonyElixir.Tracker.Issue
 
-  @callback fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
-  @callback fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
-  @callback fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
-  @callback create_comment(String.t(), String.t()) :: :ok | {:error, term()}
-  @callback update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
+  @adapters %{
+    "linear" => SymphonyElixir.Linear.Adapter,
+    "memory" => SymphonyElixir.Tracker.Memory
+  }
 
-  @spec fetch_candidate_issues() :: {:ok, [term()]} | {:error, term()}
-  def fetch_candidate_issues do
-    adapter().fetch_candidate_issues()
-  end
+  @callback fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  @callback fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  @callback agent_tool_specs() :: [map()]
+  @callback execute_agent_tool(String.t(), term(), keyword()) :: map()
+  @callback secret_environment_names(map()) :: [String.t()]
+  @callback validate_config(map()) :: :ok | {:error, term()}
 
-  @spec fetch_issues_by_states([String.t()]) :: {:ok, [term()]} | {:error, term()}
+  @optional_callbacks agent_tool_specs: 0,
+                      execute_agent_tool: 3,
+                      secret_environment_names: 1,
+                      validate_config: 1
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issues_by_states(states) do
     adapter().fetch_issues_by_states(states)
   end
 
-  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [term()]} | {:error, term()}
-  def fetch_issue_states_by_ids(issue_ids) do
-    adapter().fetch_issue_states_by_ids(issue_ids)
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(issue_ids) do
+    adapter().fetch_issues_by_ids(issue_ids)
   end
 
-  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
-  def create_comment(issue_id, body) do
-    adapter().create_comment(issue_id, body)
+  @spec agent_tool_specs() :: [map()]
+  def agent_tool_specs do
+    adapter_agent_tool_specs(adapter())
   end
 
-  @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
-  def update_issue_state(issue_id, state_name) do
-    adapter().update_issue_state(issue_id, state_name)
+  @spec execute_agent_tool(String.t(), term(), keyword()) :: map()
+  def execute_agent_tool(tool, arguments, opts \\ []) do
+    execute_agent_tool_with_adapter(adapter(), tool, arguments, opts)
+  end
+
+  @doc """
+  Environment variables containing tracker credentials that must not be
+  inherited by the Codex child process.
+  """
+  @spec secret_environment_names() :: [String.t()]
+  def secret_environment_names do
+    tracker_settings = Config.settings!().tracker
+    adapter_secret_environment_names(adapter_for_settings!(tracker_settings), tracker_settings)
+  end
+
+  @doc """
+  Captures the selected adapter and effective tracker settings for one
+  app-server session so tool advertisement and execution cannot drift across a
+  workflow reload.
+  """
+  @spec bind_agent_tools() :: map()
+  def bind_agent_tools do
+    tracker_settings = Config.settings!().tracker
+    adapter = adapter_for_settings!(tracker_settings)
+
+    %{
+      adapter: adapter,
+      tracker_settings: tracker_settings,
+      tool_specs: adapter_agent_tool_specs(adapter),
+      secret_environment_names: adapter_secret_environment_names(adapter, tracker_settings)
+    }
+  end
+
+  @spec execute_bound_agent_tool(map(), String.t(), term(), keyword()) :: map()
+  def execute_bound_agent_tool(
+        %{adapter: adapter, tracker_settings: tracker_settings},
+        tool,
+        arguments,
+        opts \\ []
+      ) do
+    execute_agent_tool_with_adapter(
+      adapter,
+      tool,
+      arguments,
+      Keyword.put(opts, :tracker_settings, tracker_settings)
+    )
+  end
+
+  @spec validate_config(map()) :: :ok | {:error, term()}
+  def validate_config(%{kind: kind} = tracker_settings) do
+    with {:ok, adapter} <- adapter_for_kind(kind) do
+      if Code.ensure_loaded?(adapter) and function_exported?(adapter, :validate_config, 1) do
+        adapter.validate_config(tracker_settings)
+      else
+        :ok
+      end
+    end
   end
 
   @spec adapter() :: module()
   def adapter do
-    case Config.settings!().tracker.kind do
-      "memory" -> SymphonyElixir.Tracker.Memory
-      _ -> SymphonyElixir.Linear.Adapter
+    Config.settings!().tracker
+    |> adapter_for_settings!()
+  end
+
+  @spec adapter_for_kind(String.t()) :: {:ok, module()} | {:error, term()}
+  def adapter_for_kind(kind) do
+    case Map.fetch(@adapters, kind) do
+      {:ok, adapter} -> {:ok, adapter}
+      :error -> {:error, {:unsupported_tracker_kind, kind}}
     end
+  end
+
+  defp adapter_for_settings!(%{kind: kind}) do
+    {:ok, adapter} = adapter_for_kind(kind)
+    adapter
+  end
+
+  defp adapter_agent_tool_specs(adapter) do
+    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :agent_tool_specs, 0) do
+      adapter.agent_tool_specs()
+    else
+      []
+    end
+  end
+
+  defp execute_agent_tool_with_adapter(adapter, tool, arguments, opts) do
+    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :execute_agent_tool, 3) do
+      adapter.execute_agent_tool(tool, arguments, opts)
+    else
+      unsupported_agent_tool_response(tool)
+    end
+  end
+
+  defp adapter_secret_environment_names(adapter, tracker_settings) do
+    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :secret_environment_names, 1) do
+      adapter.secret_environment_names(tracker_settings)
+    else
+      []
+    end
+  end
+
+  defp unsupported_agent_tool_response(tool) do
+    output =
+      Jason.encode!(%{
+        "error" => %{
+          "message" => "Unsupported dynamic tool: #{inspect(tool)}.",
+          "supportedTools" => []
+        }
+      })
+
+    %{
+      "success" => false,
+      "output" => output,
+      "contentItems" => [%{"type" => "inputText", "text" => output}]
+    }
   end
 end

--- a/elixir/lib/symphony_elixir/tracker/issue.ex
+++ b/elixir/lib/symphony_elixir/tracker/issue.ex
@@ -1,10 +1,17 @@
-defmodule SymphonyElixir.Linear.Issue do
+defmodule SymphonyElixir.Tracker.Issue do
   @moduledoc """
-  Normalized Linear issue representation used by the orchestrator.
+  Normalized work item representation used by the orchestrator.
+
+  `id` is the stable dispatch identity for the configured tracker scope. It may
+  differ from a provider's underlying issue ID when the scheduled item is a
+  board or project entry. `native_ref` carries non-secret provider identifiers
+  needed by provider-native agent tools. `identifier` remains the human-readable
+  workspace key and must be unique within that scope.
   """
 
   defstruct [
     :id,
+    :native_ref,
     :identifier,
     :title,
     :description,
@@ -15,13 +22,14 @@ defmodule SymphonyElixir.Linear.Issue do
     :assignee_id,
     blocked_by: [],
     labels: [],
-    assigned_to_worker: true,
+    dispatchable: false,
     created_at: nil,
     updated_at: nil
   ]
 
   @type t :: %__MODULE__{
           id: String.t() | nil,
+          native_ref: map() | nil,
           identifier: String.t() | nil,
           title: String.t() | nil,
           description: String.t() | nil,
@@ -31,7 +39,8 @@ defmodule SymphonyElixir.Linear.Issue do
           url: String.t() | nil,
           assignee_id: String.t() | nil,
           labels: [String.t()],
-          assigned_to_worker: boolean(),
+          blocked_by: [map()],
+          dispatchable: boolean(),
           created_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
@@ -42,7 +51,7 @@ defmodule SymphonyElixir.Linear.Issue do
   end
 
   @spec routable?(t(), [String.t()]) :: boolean()
-  def routable?(%__MODULE__{assigned_to_worker: true, labels: labels}, required_labels)
+  def routable?(%__MODULE__{dispatchable: true, labels: labels}, required_labels)
       when is_list(labels) and is_list(required_labels) do
     issue_labels = MapSet.new(labels, &normalize_label/1)
     Enum.all?(required_labels, &MapSet.member?(issue_labels, normalize_label(&1)))

--- a/elixir/lib/symphony_elixir/tracker/issue.ex
+++ b/elixir/lib/symphony_elixir/tracker/issue.ex
@@ -6,7 +6,7 @@ defmodule SymphonyElixir.Tracker.Issue do
   differ from a provider's underlying issue ID when the scheduled item is a
   board or project entry. `native_ref` carries non-secret provider identifiers
   needed by provider-native agent tools. `identifier` remains the human-readable
-  workspace key and must be unique within that scope.
+  value used to derive the workspace key and must be unique within that scope.
   """
 
   defstruct [

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -30,6 +30,9 @@ defmodule SymphonyElixir.Tracker.Memory do
      end)}
   end
 
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(_tracker_settings), do: []
+
   defp configured_issues do
     Application.get_env(:symphony_elixir, :memory_tracker_issues, [])
   end

--- a/elixir/lib/symphony_elixir/tracker/memory.ex
+++ b/elixir/lib/symphony_elixir/tracker/memory.ex
@@ -5,12 +5,7 @@ defmodule SymphonyElixir.Tracker.Memory do
 
   @behaviour SymphonyElixir.Tracker
 
-  alias SymphonyElixir.Linear.Issue
-
-  @spec fetch_candidate_issues() :: {:ok, [Issue.t()]} | {:error, term()}
-  def fetch_candidate_issues do
-    {:ok, issue_entries()}
-  end
+  alias SymphonyElixir.Tracker.Issue
 
   @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
   def fetch_issues_by_states(state_names) do
@@ -25,8 +20,8 @@ defmodule SymphonyElixir.Tracker.Memory do
      end)}
   end
 
-  @spec fetch_issue_states_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
-  def fetch_issue_states_by_ids(issue_ids) do
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(issue_ids) do
     wanted_ids = MapSet.new(issue_ids)
 
     {:ok,
@@ -35,31 +30,12 @@ defmodule SymphonyElixir.Tracker.Memory do
      end)}
   end
 
-  @spec create_comment(String.t(), String.t()) :: :ok | {:error, term()}
-  def create_comment(issue_id, body) do
-    send_event({:memory_tracker_comment, issue_id, body})
-    :ok
-  end
-
-  @spec update_issue_state(String.t(), String.t()) :: :ok | {:error, term()}
-  def update_issue_state(issue_id, state_name) do
-    send_event({:memory_tracker_state_update, issue_id, state_name})
-    :ok
-  end
-
   defp configured_issues do
     Application.get_env(:symphony_elixir, :memory_tracker_issues, [])
   end
 
   defp issue_entries do
     Enum.filter(configured_issues(), &match?(%Issue{}, &1))
-  end
-
-  defp send_event(message) do
-    case Application.get_env(:symphony_elixir, :memory_tracker_recipient) do
-      pid when is_pid(pid) -> send(pid, message)
-      _ -> :ok
-    end
   end
 
   defp normalize_state(state) when is_binary(state) do

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -16,7 +16,7 @@ defmodule SymphonyElixir.Workspace do
     issue_context = issue_context(issue_or_identifier)
 
     try do
-      safe_id = workspace_key(issue_context)
+      safe_id = workspace_key(issue_or_identifier)
 
       with {:ok, workspace} <- workspace_path_for_issue(safe_id, worker_host),
            :ok <- validate_workspace_path(workspace, worker_host),
@@ -133,9 +133,7 @@ defmodule SymphonyElixir.Workspace do
   @spec remove_issue_workspaces(term(), worker_host()) :: :ok
   def remove_issue_workspaces(%{id: _issue_id, identifier: _identifier} = issue, worker_host)
       when is_binary(worker_host) do
-    safe_id = issue |> issue_context() |> workspace_key()
-
-    case workspace_path_for_issue(safe_id, worker_host) do
+    case workspace_path_for_issue(workspace_key(issue), worker_host) do
       {:ok, workspace} -> remove(workspace, worker_host)
       {:error, _reason} -> :ok
     end
@@ -144,11 +142,9 @@ defmodule SymphonyElixir.Workspace do
   end
 
   def remove_issue_workspaces(%{id: _issue_id, identifier: _identifier} = issue, nil) do
-    safe_id = issue |> issue_context() |> workspace_key()
-
     case Config.settings!().worker.ssh_hosts do
       [] ->
-        case workspace_path_for_issue(safe_id, nil) do
+        case workspace_path_for_issue(workspace_key(issue), nil) do
           {:ok, workspace} -> remove(workspace, nil)
           {:error, _reason} -> :ok
         end
@@ -161,9 +157,7 @@ defmodule SymphonyElixir.Workspace do
   end
 
   def remove_issue_workspaces(identifier, worker_host) when is_binary(identifier) and is_binary(worker_host) do
-    safe_id = safe_identifier(identifier)
-
-    case workspace_path_for_issue(safe_id, worker_host) do
+    case workspace_path_for_issue(workspace_key(identifier), worker_host) do
       {:ok, workspace} -> remove(workspace, worker_host)
       {:error, _reason} -> :ok
     end
@@ -172,11 +166,9 @@ defmodule SymphonyElixir.Workspace do
   end
 
   def remove_issue_workspaces(identifier, nil) when is_binary(identifier) do
-    safe_id = safe_identifier(identifier)
-
     case Config.settings!().worker.ssh_hosts do
       [] ->
-        case workspace_path_for_issue(safe_id, nil) do
+        case workspace_path_for_issue(workspace_key(identifier), nil) do
           {:ok, workspace} -> remove(workspace, nil)
           {:error, _reason} -> :ok
         end
@@ -188,9 +180,7 @@ defmodule SymphonyElixir.Workspace do
     :ok
   end
 
-  def remove_issue_workspaces(_identifier, _worker_host) do
-    :ok
-  end
+  def remove_issue_workspaces(_identifier, _worker_host), do: :ok
 
   @spec run_before_run_hook(Path.t(), map() | String.t() | nil, worker_host()) ::
           :ok | {:error, term()}
@@ -232,24 +222,34 @@ defmodule SymphonyElixir.Workspace do
     {:ok, Path.join(Config.settings!().workspace.root, safe_id)}
   end
 
-  defp safe_identifier(identifier) do
-    String.replace(identifier || "issue", ~r/[^a-zA-Z0-9._-]/, "_")
-  end
+  @doc """
+  Returns the collision-safe directory name for an issue identifier.
 
-  defp workspace_key(%{issue_id: issue_id, issue_identifier: identifier}) do
+  The hash is derived from the original identifier so callers that only know the identifier can
+  derive the same key as callers holding a full tracker issue.
+  """
+  @spec workspace_key(map() | String.t() | nil) :: String.t()
+  def workspace_key(%{identifier: identifier}), do: workspace_key(identifier)
+
+  def workspace_key(identifier) when is_binary(identifier) do
     safe_identifier = safe_identifier(identifier)
 
-    if safe_identifier == identifier or not is_binary(issue_id) do
+    if safe_identifier == identifier do
       safe_identifier
     else
-      "#{safe_identifier}--#{short_issue_hash(issue_id)}"
+      "#{safe_identifier}--#{short_identifier_hash(identifier)}"
     end
   end
 
-  defp short_issue_hash(issue_id) do
-    :crypto.hash(:sha256, issue_id)
+  def workspace_key(_identifier), do: "issue"
+
+  defp safe_identifier(identifier) when is_binary(identifier),
+    do: String.replace(identifier, ~r/[^a-zA-Z0-9._-]/, "_")
+
+  defp short_identifier_hash(identifier) do
+    :crypto.hash(:sha256, identifier)
     |> Base.encode16(case: :lower)
-    |> binary_part(0, 8)
+    |> binary_part(0, 16)
   end
 
   defp maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -16,7 +16,7 @@ defmodule SymphonyElixir.Workspace do
     issue_context = issue_context(issue_or_identifier)
 
     try do
-      safe_id = safe_identifier(issue_context.issue_identifier)
+      safe_id = workspace_key(issue_context)
 
       with {:ok, workspace} <- workspace_path_for_issue(safe_id, worker_host),
            :ok <- validate_workspace_path(workspace, worker_host),
@@ -131,6 +131,35 @@ defmodule SymphonyElixir.Workspace do
   def remove_issue_workspaces(identifier), do: remove_issue_workspaces(identifier, nil)
 
   @spec remove_issue_workspaces(term(), worker_host()) :: :ok
+  def remove_issue_workspaces(%{id: _issue_id, identifier: _identifier} = issue, worker_host)
+      when is_binary(worker_host) do
+    safe_id = issue |> issue_context() |> workspace_key()
+
+    case workspace_path_for_issue(safe_id, worker_host) do
+      {:ok, workspace} -> remove(workspace, worker_host)
+      {:error, _reason} -> :ok
+    end
+
+    :ok
+  end
+
+  def remove_issue_workspaces(%{id: _issue_id, identifier: _identifier} = issue, nil) do
+    safe_id = issue |> issue_context() |> workspace_key()
+
+    case Config.settings!().worker.ssh_hosts do
+      [] ->
+        case workspace_path_for_issue(safe_id, nil) do
+          {:ok, workspace} -> remove(workspace, nil)
+          {:error, _reason} -> :ok
+        end
+
+      worker_hosts ->
+        Enum.each(worker_hosts, &remove_issue_workspaces(issue, &1))
+    end
+
+    :ok
+  end
+
   def remove_issue_workspaces(identifier, worker_host) when is_binary(identifier) and is_binary(worker_host) do
     safe_id = safe_identifier(identifier)
 
@@ -205,6 +234,22 @@ defmodule SymphonyElixir.Workspace do
 
   defp safe_identifier(identifier) do
     String.replace(identifier || "issue", ~r/[^a-zA-Z0-9._-]/, "_")
+  end
+
+  defp workspace_key(%{issue_id: issue_id, issue_identifier: identifier}) do
+    safe_identifier = safe_identifier(identifier)
+
+    if safe_identifier == identifier or not is_binary(issue_id) do
+      safe_identifier
+    else
+      "#{safe_identifier}--#{short_issue_hash(issue_id)}"
+    end
+  end
+
+  defp short_issue_hash(issue_id) do
+    :crypto.hash(:sha256, issue_id)
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 8)
   end
 
   defp maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -3,7 +3,7 @@ defmodule SymphonyElixirWeb.Presenter do
   Shared projections for the observability API and dashboard.
   """
 
-  alias SymphonyElixir.{Config, Orchestrator, StatusDashboard}
+  alias SymphonyElixir.{Config, Orchestrator, StatusDashboard, Workspace}
 
   @spec state_payload(GenServer.name(), timeout()) :: map()
   def state_payload(orchestrator, snapshot_timeout_ms) do
@@ -198,7 +198,7 @@ defmodule SymphonyElixirWeb.Presenter do
     (running && Map.get(running, :workspace_path)) ||
       (retry && Map.get(retry, :workspace_path)) ||
       (blocked && Map.get(blocked, :workspace_path)) ||
-      Path.join(Config.settings!().workspace.root, issue_identifier)
+      Path.join(Config.settings!().workspace.root, Workspace.workspace_key(issue_identifier))
   end
 
   defp workspace_host(running, retry, blocked) do

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -12,11 +12,11 @@ defmodule SymphonyElixir.TestSupport do
       alias SymphonyElixir.Config
       alias SymphonyElixir.HttpServer
       alias SymphonyElixir.Linear.Client
-      alias SymphonyElixir.Linear.Issue
       alias SymphonyElixir.Orchestrator
       alias SymphonyElixir.PromptBuilder
       alias SymphonyElixir.StatusDashboard
       alias SymphonyElixir.Tracker
+      alias SymphonyElixir.Tracker.Issue
       alias SymphonyElixir.Workflow
       alias SymphonyElixir.WorkflowStore
       alias SymphonyElixir.Workspace
@@ -42,7 +42,6 @@ defmodule SymphonyElixir.TestSupport do
           Application.delete_env(:symphony_elixir, :workflow_file_path)
           Application.delete_env(:symphony_elixir, :server_port_override)
           Application.delete_env(:symphony_elixir, :memory_tracker_issues)
-          Application.delete_env(:symphony_elixir, :memory_tracker_recipient)
           File.rm_rf(workflow_root)
         end)
 

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -1341,6 +1341,93 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
+  test "app server does not pass tracker credentials to the local Codex child" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-app-server-secret-env-#{System.unique_integer([:positive])}"
+      )
+
+    custom_secret_env = "SYMP_CUSTOM_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
+    previous_secret = System.get_env("LINEAR_API_KEY")
+    previous_custom_secret = System.get_env(custom_secret_env)
+    previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+
+    on_exit(fn ->
+      restore_env("LINEAR_API_KEY", previous_secret)
+      restore_env(custom_secret_env, previous_custom_secret)
+      restore_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+    end)
+
+    try do
+      workspace_root = Path.join(test_root, "workspaces")
+      workspace = Path.join(workspace_root, "MT-SECRET")
+      codex_binary = Path.join(test_root, "fake-codex")
+      trace_file = Path.join(test_root, "codex-secret-env.trace")
+
+      File.mkdir_p!(workspace)
+      System.put_env("LINEAR_API_KEY", "canonical-secret-that-must-not-reach-child")
+      System.put_env(custom_secret_env, "custom-secret-that-must-not-reach-child")
+      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+
+      File.write!(codex_binary, """
+      #!/bin/sh
+      trace_file="$SYMP_TEST_CODEx_TRACE"
+      printf 'CANONICAL_SECRET:%s\n' "$LINEAR_API_KEY" >> "$trace_file"
+      printf 'CUSTOM_SECRET:%s\n' "$#{custom_secret_env}" >> "$trace_file"
+      count=0
+
+      while IFS= read -r line; do
+        count=$((count + 1))
+
+        case "$count" in
+          1)
+            printf '%s\n' '{"id":1,"result":{}}'
+            ;;
+          2)
+            printf '%s\n' '{"id":2,"result":{"thread":{"id":"thread-secret"}}}'
+            ;;
+          3)
+            printf '%s\n' '{"id":3,"result":{"turn":{"id":"turn-secret"}}}'
+            ;;
+          4)
+            printf '%s\n' '{"method":"turn/completed"}'
+            exit 0
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+      done
+      """)
+
+      File.chmod!(codex_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        tracker_api_token: "$#{custom_secret_env}",
+        codex_command: "#{codex_binary} app-server"
+      )
+
+      issue = %Issue{
+        id: "issue-secret-env",
+        identifier: "MT-SECRET",
+        title: "Keep tracker auth in Symphony",
+        description: "Ensure the child cannot bypass the centrally-authenticated tool boundary",
+        state: "In Progress",
+        url: "https://example.org/issues/MT-SECRET",
+        labels: ["security"]
+      }
+
+      assert {:ok, _result} = AppServer.run(workspace, "Do not inherit tracker auth", issue)
+      assert File.read!(trace_file) =~ "CANONICAL_SECRET:\n"
+      assert File.read!(trace_file) =~ "CUSTOM_SECRET:\n"
+      refute File.read!(trace_file) =~ "secret-that-must-not-reach-child"
+    after
+      File.rm_rf(test_root)
+    end
+  end
+
   test "app server launches over ssh for remote workers" do
     test_root =
       Path.join(
@@ -1428,6 +1515,7 @@ defmodule SymphonyElixir.AppServerTest do
       assert argv_line =~ "-T -p 2200 worker-01 bash -lc"
       assert argv_line =~ "cd "
       assert argv_line =~ remote_workspace
+      assert argv_line =~ "unset LINEAR_API_KEY"
       assert argv_line =~ "exec "
       assert argv_line =~ "fake-remote-codex app-server"
 

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -1349,30 +1349,44 @@ defmodule SymphonyElixir.AppServerTest do
       )
 
     custom_secret_env = "SYMP_CUSTOM_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
+    profile_marker_env = "SYMP_TEST_BASH_PROFILE_LOADED_#{System.unique_integer([:positive])}"
     previous_secret = System.get_env("LINEAR_API_KEY")
     previous_custom_secret = System.get_env(custom_secret_env)
+    previous_home = System.get_env("HOME")
     previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
 
     on_exit(fn ->
       restore_env("LINEAR_API_KEY", previous_secret)
       restore_env(custom_secret_env, previous_custom_secret)
+      restore_env("HOME", previous_home)
       restore_env("SYMP_TEST_CODEx_TRACE", previous_trace)
     end)
 
     try do
+      bash_home = Path.join(test_root, "bash-home")
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-SECRET")
       codex_binary = Path.join(test_root, "fake-codex")
       trace_file = Path.join(test_root, "codex-secret-env.trace")
 
+      File.mkdir_p!(bash_home)
       File.mkdir_p!(workspace)
+
+      File.write!(Path.join(bash_home, ".bash_profile"), """
+      export LINEAR_API_KEY='profile-canonical-secret-that-must-not-reach-child'
+      export #{custom_secret_env}='profile-custom-secret-that-must-not-reach-child'
+      export #{profile_marker_env}=1
+      """)
+
       System.put_env("LINEAR_API_KEY", "canonical-secret-that-must-not-reach-child")
       System.put_env(custom_secret_env, "custom-secret-that-must-not-reach-child")
+      System.put_env("HOME", bash_home)
       System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
 
       File.write!(codex_binary, """
       #!/bin/sh
       trace_file="$SYMP_TEST_CODEx_TRACE"
+      printf 'PROFILE_LOADED:%s\n' "$#{profile_marker_env}" >> "$trace_file"
       printf 'CANONICAL_SECRET:%s\n' "$LINEAR_API_KEY" >> "$trace_file"
       printf 'CUSTOM_SECRET:%s\n' "$#{custom_secret_env}" >> "$trace_file"
       count=0
@@ -1420,6 +1434,7 @@ defmodule SymphonyElixir.AppServerTest do
       }
 
       assert {:ok, _result} = AppServer.run(workspace, "Do not inherit tracker auth", issue)
+      assert File.read!(trace_file) =~ "PROFILE_LOADED:1\n"
       assert File.read!(trace_file) =~ "CANONICAL_SECRET:\n"
       assert File.read!(trace_file) =~ "CUSTOM_SECRET:\n"
       refute File.read!(trace_file) =~ "secret-that-must-not-reach-child"

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -372,7 +372,8 @@ defmodule SymphonyElixir.CoreTest do
       description: "Keep one worker active while the orchestrator restarts",
       state: "In Progress",
       url: "https://example.org/issues/MT-#{issue_suffix}",
-      labels: []
+      labels: [],
+      dispatchable: true
     }
 
     on_exit(fn ->
@@ -471,7 +472,7 @@ defmodule SymphonyElixir.CoreTest do
   end
 
   test "linear issue state reconciliation fetch with no running issues is a no-op" do
-    assert {:ok, []} = Client.fetch_issue_states_by_ids([])
+    assert {:ok, []} = Client.fetch_issues_by_ids([])
   end
 
   test "non-active issue state stops running agent without cleaning workspace" do
@@ -706,7 +707,8 @@ defmodule SymphonyElixir.CoreTest do
       state: "In Progress",
       title: "Active state refresh",
       description: "State should be refreshed",
-      labels: []
+      labels: [],
+      dispatchable: true
     }
 
     updated_state = Orchestrator.reconcile_issue_states_for_test([issue], state)
@@ -737,7 +739,7 @@ defmodule SymphonyElixir.CoreTest do
             id: issue_id,
             identifier: "MT-561",
             state: "In Progress",
-            assigned_to_worker: true
+            dispatchable: true
           },
           started_at: DateTime.utc_now()
         }
@@ -754,7 +756,7 @@ defmodule SymphonyElixir.CoreTest do
       title: "Reassigned active issue",
       description: "Worker should stop",
       labels: [],
-      assigned_to_worker: false
+      dispatchable: false
     }
 
     updated_state = Orchestrator.reconcile_issue_states_for_test([issue], state)
@@ -1290,7 +1292,7 @@ defmodule SymphonyElixir.CoreTest do
 
     prompt = PromptBuilder.build_prompt(issue)
 
-    assert prompt =~ "You are working on a Linear issue."
+    assert prompt =~ "You are working on an issue from the configured tracker."
     assert prompt =~ "Identifier: MT-777"
     assert prompt =~ "Title: Make fallback prompt useful"
     assert prompt =~ "Body:"
@@ -1731,7 +1733,8 @@ defmodule SymphonyElixir.CoreTest do
              identifier: "MT-247",
              title: "Continue until done",
              description: "Still active after first turn",
-             state: state
+             state: state,
+             dispatchable: true
            }
          ]}
       end
@@ -1848,7 +1851,8 @@ defmodule SymphonyElixir.CoreTest do
              identifier: "MT-248",
              title: "Stop at max turns",
              description: "Still active",
-             state: "In Progress"
+             state: "In Progress",
+             dispatchable: true
            }
          ]}
       end

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -116,7 +116,7 @@ defmodule SymphonyElixir.CoreTest do
     tracker = Map.get(config, "tracker", %{})
     assert is_map(tracker)
     assert Map.get(tracker, "kind") == "linear"
-    assert is_binary(Map.get(tracker, "project_slug"))
+    assert is_binary(get_in(tracker, ["provider", "project_slug"]))
     assert is_list(Map.get(tracker, "active_states"))
     assert is_list(Map.get(tracker, "terminal_states"))
 
@@ -1380,12 +1380,12 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "Current status: In Progress"
     assert prompt =~ "https://example.org/issues/MT-616/use-rich-templates-for-workflowmd"
     assert prompt =~ "This is an unattended orchestration session."
-    assert prompt =~ "Only stop early for a true blocker"
+    assert prompt =~ "Only stop early for a true external blocker"
     assert prompt =~ "Do not include \"next steps for user\""
     assert prompt =~ "open and follow `.codex/skills/land/SKILL.md`"
     assert prompt =~ "Do not call `gh pr merge` directly"
-    assert prompt =~ "Continuation context:"
-    assert prompt =~ "retry attempt #2"
+    assert prompt =~ "Follow-up context:"
+    assert prompt =~ "follow-up attempt #2"
   end
 
   test "prompt builder adds continuation guidance for retries" do

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -42,6 +42,38 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
            ]
   end
 
+  test "bound tools keep the adapter and auth snapshot from session startup" do
+    write_workflow_file!(Workflow.workflow_file_path(),
+      tracker_kind: "linear",
+      tracker_api_token: "session-token",
+      tracker_project_slug: "session-project"
+    )
+
+    binding = DynamicTool.bind()
+
+    write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
+    assert DynamicTool.tool_specs() == []
+
+    test_pid = self()
+
+    response =
+      DynamicTool.execute(
+        "linear_graphql",
+        %{"query" => "query Viewer { viewer { id } }"},
+        binding: binding,
+        linear_client: fn query, variables, opts ->
+          send(test_pid, {:bound_linear_client_called, query, variables, opts})
+          {:ok, %{"data" => %{"viewer" => %{"id" => "usr_bound"}}}}
+        end
+      )
+
+    assert_received {:bound_linear_client_called, "query Viewer { viewer { id } }", %{}, [tracker_settings: tracker_settings]}
+
+    assert tracker_settings.api_key == "session-token"
+    assert tracker_settings.project_slug == "session-project"
+    assert response["success"] == true
+  end
+
   test "linear_graphql returns successful GraphQL responses as tool text" do
     test_pid = self()
 
@@ -245,7 +277,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
 
     assert Jason.decode!(missing_token["output"]) == %{
              "error" => %{
-               "message" => "Symphony is missing Linear auth. Set `linear.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
+               "message" => "Symphony is missing Linear auth. Set `tracker.provider.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
              }
            }
 

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1,7 +1,8 @@
 defmodule SymphonyElixir.Codex.DynamicToolTest do
   use SymphonyElixir.TestSupport
 
-  alias SymphonyElixir.Codex.DynamicTool
+  alias SymphonyElixir.Codex.DynamicTool, as: BoundDynamicTool
+  alias SymphonyElixir.Linear.AgentTool, as: DynamicTool
 
   test "tool_specs advertises the linear_graphql input contract" do
     assert [
@@ -23,7 +24,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
   end
 
   test "unsupported tools return a failure payload with the supported tool list" do
-    response = DynamicTool.execute("not_a_real_tool", %{})
+    response = DynamicTool.execute("not_a_real_tool", %{}, [])
 
     assert response["success"] == false
 
@@ -49,18 +50,18 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
       tracker_project_slug: "session-project"
     )
 
-    binding = DynamicTool.bind()
+    binding = BoundDynamicTool.bind()
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
-    assert DynamicTool.tool_specs() == []
+    assert BoundDynamicTool.bind().tool_specs == []
 
     test_pid = self()
 
     response =
-      DynamicTool.execute(
+      BoundDynamicTool.execute(
         "linear_graphql",
         %{"query" => "query Viewer { viewer { id } }"},
-        binding: binding,
+        binding,
         linear_client: fn query, variables, opts ->
           send(test_pid, {:bound_linear_client_called, query, variables, opts})
           {:ok, %{"data" => %{"viewer" => %{"id" => "usr_bound"}}}}
@@ -155,7 +156,7 @@ defmodule SymphonyElixir.Codex.DynamicToolTest do
   end
 
   test "linear_graphql rejects blank raw query strings even when using the default client" do
-    response = DynamicTool.execute("linear_graphql", "   ")
+    response = DynamicTool.execute("linear_graphql", "   ", [])
 
     assert response["success"] == false
 

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -209,9 +209,6 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert SymphonyElixir.Tracker.adapter() == Memory
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_states([" in progress ", 42])
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_ids(["issue-1"])
-    assert SymphonyElixir.Tracker.agent_tool_specs() == []
-    assert SymphonyElixir.Tracker.secret_environment_names() == []
-    assert SymphonyElixir.Tracker.execute_agent_tool("not_a_memory_tool", %{})["success"] == false
 
     binding = SymphonyElixir.Tracker.bind_agent_tools()
     assert binding.adapter == Memory
@@ -227,7 +224,7 @@ defmodule SymphonyElixir.ExtensionsTest do
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "linear")
     assert SymphonyElixir.Tracker.adapter() == Adapter
-    assert SymphonyElixir.Tracker.secret_environment_names() == ["LINEAR_API_KEY"]
+    assert SymphonyElixir.Tracker.bind_agent_tools().secret_environment_names == ["LINEAR_API_KEY"]
   end
 
   test "linear adapter delegates reads and advertises its native agent tool" do

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -10,32 +10,14 @@ defmodule SymphonyElixir.ExtensionsTest do
   @endpoint SymphonyElixirWeb.Endpoint
 
   defmodule FakeLinearClient do
-    def fetch_candidate_issues do
-      send(self(), :fetch_candidate_issues_called)
-      {:ok, [:candidate]}
-    end
-
     def fetch_issues_by_states(states) do
       send(self(), {:fetch_issues_by_states_called, states})
       {:ok, states}
     end
 
-    def fetch_issue_states_by_ids(issue_ids) do
-      send(self(), {:fetch_issue_states_by_ids_called, issue_ids})
+    def fetch_issues_by_ids(issue_ids) do
+      send(self(), {:fetch_issues_by_ids_called, issue_ids})
       {:ok, issue_ids}
-    end
-
-    def graphql(query, variables) do
-      send(self(), {:graphql_called, query, variables})
-
-      case Process.get({__MODULE__, :graphql_results}) do
-        [result | rest] ->
-          Process.put({__MODULE__, :graphql_results}, rest)
-          result
-
-        _ ->
-          Process.get({__MODULE__, :graphql_result})
-      end
     end
   end
 
@@ -221,139 +203,43 @@ defmodule SymphonyElixir.ExtensionsTest do
   test "tracker delegates to memory and linear adapters" do
     issue = %Issue{id: "issue-1", identifier: "MT-1", state: "In Progress"}
     Application.put_env(:symphony_elixir, :memory_tracker_issues, [issue, %{id: "ignored"}])
-    Application.put_env(:symphony_elixir, :memory_tracker_recipient, self())
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "memory")
 
     assert Config.settings!().tracker.kind == "memory"
     assert SymphonyElixir.Tracker.adapter() == Memory
-    assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_candidate_issues()
     assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_states([" in progress ", 42])
-    assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issue_states_by_ids(["issue-1"])
-    assert :ok = SymphonyElixir.Tracker.create_comment("issue-1", "comment")
-    assert :ok = SymphonyElixir.Tracker.update_issue_state("issue-1", "Done")
-    assert_receive {:memory_tracker_comment, "issue-1", "comment"}
-    assert_receive {:memory_tracker_state_update, "issue-1", "Done"}
+    assert {:ok, [^issue]} = SymphonyElixir.Tracker.fetch_issues_by_ids(["issue-1"])
+    assert SymphonyElixir.Tracker.agent_tool_specs() == []
+    assert SymphonyElixir.Tracker.secret_environment_names() == []
+    assert SymphonyElixir.Tracker.execute_agent_tool("not_a_memory_tool", %{})["success"] == false
 
-    Application.delete_env(:symphony_elixir, :memory_tracker_recipient)
-    assert :ok = Memory.create_comment("issue-1", "quiet")
-    assert :ok = Memory.update_issue_state("issue-1", "Quiet")
+    binding = SymphonyElixir.Tracker.bind_agent_tools()
+    assert binding.adapter == Memory
+    assert binding.tool_specs == []
+    assert binding.secret_environment_names == []
+
+    assert SymphonyElixir.Tracker.execute_bound_agent_tool(binding, "not_a_memory_tool", %{})[
+             "success"
+           ] == false
+
+    assert {:error, {:unsupported_tracker_kind, "jira"}} =
+             SymphonyElixir.Tracker.adapter_for_kind("jira")
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "linear")
     assert SymphonyElixir.Tracker.adapter() == Adapter
+    assert SymphonyElixir.Tracker.secret_environment_names() == ["LINEAR_API_KEY"]
   end
 
-  test "linear adapter delegates reads and validates mutation responses" do
+  test "linear adapter delegates reads and advertises its native agent tool" do
     Application.put_env(:symphony_elixir, :linear_client_module, FakeLinearClient)
-
-    assert {:ok, [:candidate]} = Adapter.fetch_candidate_issues()
-    assert_receive :fetch_candidate_issues_called
 
     assert {:ok, ["Todo"]} = Adapter.fetch_issues_by_states(["Todo"])
     assert_receive {:fetch_issues_by_states_called, ["Todo"]}
 
-    assert {:ok, ["issue-1"]} = Adapter.fetch_issue_states_by_ids(["issue-1"])
-    assert_receive {:fetch_issue_states_by_ids_called, ["issue-1"]}
+    assert {:ok, ["issue-1"]} = Adapter.fetch_issues_by_ids(["issue-1"])
+    assert_receive {:fetch_issues_by_ids_called, ["issue-1"]}
 
-    Process.put(
-      {FakeLinearClient, :graphql_result},
-      {:ok, %{"data" => %{"commentCreate" => %{"success" => true}}}}
-    )
-
-    assert :ok = Adapter.create_comment("issue-1", "hello")
-    assert_receive {:graphql_called, create_comment_query, %{body: "hello", issueId: "issue-1"}}
-    assert create_comment_query =~ "commentCreate"
-
-    Process.put(
-      {FakeLinearClient, :graphql_result},
-      {:ok, %{"data" => %{"commentCreate" => %{"success" => false}}}}
-    )
-
-    assert {:error, :comment_create_failed} =
-             Adapter.create_comment("issue-1", "broken")
-
-    Process.put({FakeLinearClient, :graphql_result}, {:error, :boom})
-
-    assert {:error, :boom} = Adapter.create_comment("issue-1", "boom")
-
-    Process.put({FakeLinearClient, :graphql_result}, {:ok, %{"data" => %{}}})
-    assert {:error, :comment_create_failed} = Adapter.create_comment("issue-1", "weird")
-
-    Process.put({FakeLinearClient, :graphql_result}, :unexpected)
-    assert {:error, :comment_create_failed} = Adapter.create_comment("issue-1", "odd")
-
-    Process.put(
-      {FakeLinearClient, :graphql_results},
-      [
-        {:ok,
-         %{
-           "data" => %{
-             "issue" => %{"team" => %{"states" => %{"nodes" => [%{"id" => "state-1"}]}}}
-           }
-         }},
-        {:ok, %{"data" => %{"issueUpdate" => %{"success" => true}}}}
-      ]
-    )
-
-    assert :ok = Adapter.update_issue_state("issue-1", "Done")
-    assert_receive {:graphql_called, state_lookup_query, %{issueId: "issue-1", stateName: "Done"}}
-    assert state_lookup_query =~ "states"
-
-    assert_receive {:graphql_called, update_issue_query, %{issueId: "issue-1", stateId: "state-1"}}
-
-    assert update_issue_query =~ "issueUpdate"
-
-    Process.put(
-      {FakeLinearClient, :graphql_results},
-      [
-        {:ok,
-         %{
-           "data" => %{
-             "issue" => %{"team" => %{"states" => %{"nodes" => [%{"id" => "state-1"}]}}}
-           }
-         }},
-        {:ok, %{"data" => %{"issueUpdate" => %{"success" => false}}}}
-      ]
-    )
-
-    assert {:error, :issue_update_failed} =
-             Adapter.update_issue_state("issue-1", "Broken")
-
-    Process.put({FakeLinearClient, :graphql_results}, [{:error, :boom}])
-
-    assert {:error, :boom} = Adapter.update_issue_state("issue-1", "Boom")
-
-    Process.put({FakeLinearClient, :graphql_results}, [{:ok, %{"data" => %{}}}])
-    assert {:error, :state_not_found} = Adapter.update_issue_state("issue-1", "Missing")
-
-    Process.put(
-      {FakeLinearClient, :graphql_results},
-      [
-        {:ok,
-         %{
-           "data" => %{
-             "issue" => %{"team" => %{"states" => %{"nodes" => [%{"id" => "state-1"}]}}}
-           }
-         }},
-        {:ok, %{"data" => %{}}}
-      ]
-    )
-
-    assert {:error, :issue_update_failed} = Adapter.update_issue_state("issue-1", "Weird")
-
-    Process.put(
-      {FakeLinearClient, :graphql_results},
-      [
-        {:ok,
-         %{
-           "data" => %{
-             "issue" => %{"team" => %{"states" => %{"nodes" => [%{"id" => "state-1"}]}}}
-           }
-         }},
-        :unexpected
-      ]
-    )
-
-    assert {:error, :issue_update_failed} = Adapter.update_issue_state("issue-1", "Odd")
+    assert [%{"name" => "linear_graphql"}] = Adapter.agent_tool_specs()
   end
 
   test "phoenix observability api preserves state, issue, and refresh responses" do

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -1006,7 +1006,8 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
         id: issue_id,
         identifier: "MT-MCP",
         state: "In Progress",
-        url: "https://example.org/issues/MT-MCP"
+        url: "https://example.org/issues/MT-MCP",
+        dispatchable: true
       },
       worker_host: "dm-dev2",
       workspace_path: "/workspaces/MT-MCP",
@@ -1078,7 +1079,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       pid: self(),
       ref: ref,
       identifier: "MT-INPUT",
-      issue: %Issue{id: issue_id, identifier: "MT-INPUT", state: "In Progress"},
+      issue: %Issue{id: issue_id, identifier: "MT-INPUT", state: "In Progress", dispatchable: true},
       session_id: "thread-input-turn-input",
       last_codex_message: %{
         event: :turn_input_required,
@@ -1132,7 +1133,12 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       pid: self(),
       ref: ref,
       identifier: "MT-INPUT-NORMAL",
-      issue: %Issue{id: issue_id, identifier: "MT-INPUT-NORMAL", state: "In Progress"},
+      issue: %Issue{
+        id: issue_id,
+        identifier: "MT-INPUT-NORMAL",
+        state: "In Progress",
+        dispatchable: true
+      },
       session_id: "thread-input-normal",
       completion: %{outcome: :input_required},
       last_codex_message: nil,

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -53,7 +53,8 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert {:ok, second_workspace} = Workspace.create_for_issue("MT/Det")
 
     assert first_workspace == second_workspace
-    assert Path.basename(first_workspace) == "MT_Det"
+    assert Path.basename(first_workspace) == Workspace.workspace_key("MT/Det")
+    assert String.starts_with?(Path.basename(first_workspace), "MT_Det--")
   end
 
   test "workspace keys disambiguate identifiers that sanitize to the same path" do
@@ -70,13 +71,14 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       underscore_issue = %Issue{id: "dispatch-underscore", identifier: "team_a-1"}
 
       assert {:ok, slash_workspace} = Workspace.create_for_issue(slash_issue)
+      assert {:ok, ^slash_workspace} = Workspace.create_for_issue("team/a-1")
       assert {:ok, underscore_workspace} = Workspace.create_for_issue(underscore_issue)
 
       refute slash_workspace == underscore_workspace
       assert Path.basename(underscore_workspace) == "team_a-1"
       assert String.starts_with?(Path.basename(slash_workspace), "team_a-1--")
 
-      assert :ok = Workspace.remove_issue_workspaces(slash_issue)
+      assert :ok = Workspace.remove_issue_workspaces("team/a-1")
       refute File.exists?(slash_workspace)
       assert File.exists?(underscore_workspace)
     after
@@ -547,8 +549,27 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert log =~ "Variable \\\"$ids\\\" got invalid value"
   end
 
-  test "linear graphql honors a bound tracker-settings snapshot" do
+  test "linear graphql honors a bound tracker-settings snapshot without loading live config" do
     parent = self()
+    original_workflow_path = Workflow.workflow_file_path()
+    workflow_store_pid = Process.whereis(WorkflowStore)
+
+    missing_workflow_path =
+      Path.join(System.tmp_dir!(), "missing-bound-workflow-#{System.unique_integer([:positive])}.md")
+
+    on_exit(fn ->
+      Workflow.set_workflow_file_path(original_workflow_path)
+
+      if is_pid(workflow_store_pid) and is_nil(Process.whereis(WorkflowStore)) do
+        Supervisor.restart_child(SymphonyElixir.Supervisor, WorkflowStore)
+      end
+    end)
+
+    if is_pid(Process.whereis(WorkflowStore)) do
+      assert :ok = Supervisor.terminate_child(SymphonyElixir.Supervisor, WorkflowStore)
+    end
+
+    Workflow.set_workflow_file_path(missing_workflow_path)
 
     assert {:ok, %{"data" => %{"viewer" => %{"id" => "viewer-bound"}}}} =
              Client.graphql(
@@ -1080,6 +1101,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     config = Config.settings!()
     assert config.tracker.api_key == api_key
+    assert config.tracker.provider["api_key"] == "$#{api_key_env_var}"
     assert config.tracker.secret_environment_names == ["LINEAR_API_KEY", api_key_env_var]
     assert config.workspace.root == Path.expand(workspace_root)
     assert config.codex.command == "#{codex_bin} app-server"
@@ -1111,6 +1133,41 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
              "assignee" => nil,
              "extra" => %{"team" => "platform"}
            }
+  end
+
+  test "linear adapter rejects invalid provider values without crashing config parsing" do
+    assert {:ok, invalid_secret_settings} =
+             Schema.parse(%{
+               tracker: %{
+                 kind: "linear",
+                 provider: %{api_key: 123, project_slug: "project"}
+               }
+             })
+
+    assert {:error, :missing_linear_api_token} =
+             Config.validate_settings(invalid_secret_settings)
+
+    assert {:ok, invalid_endpoint_settings} =
+             Schema.parse(%{
+               tracker: %{
+                 kind: "linear",
+                 provider: %{api_key: "token", project_slug: "project", endpoint: 123}
+               }
+             })
+
+    assert {:error, :invalid_linear_endpoint} =
+             Config.validate_settings(invalid_endpoint_settings)
+
+    assert {:ok, invalid_assignee_settings} =
+             Schema.parse(%{
+               tracker: %{
+                 kind: "linear",
+                 provider: %{api_key: "token", project_slug: "project", assignee: 123}
+               }
+             })
+
+    assert {:error, :invalid_linear_assignee} =
+             Config.validate_settings(invalid_assignee_settings)
   end
 
   test "schema does not inject linear defaults before an adapter is selected" do

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -56,6 +56,34 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Path.basename(first_workspace) == "MT_Det"
   end
 
+  test "workspace keys disambiguate identifiers that sanitize to the same path" do
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-workspace-collision-#{System.unique_integer([:positive])}"
+      )
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
+
+      slash_issue = %Issue{id: "dispatch-slash", identifier: "team/a-1"}
+      underscore_issue = %Issue{id: "dispatch-underscore", identifier: "team_a-1"}
+
+      assert {:ok, slash_workspace} = Workspace.create_for_issue(slash_issue)
+      assert {:ok, underscore_workspace} = Workspace.create_for_issue(underscore_issue)
+
+      refute slash_workspace == underscore_workspace
+      assert Path.basename(underscore_workspace) == "team_a-1"
+      assert String.starts_with?(Path.basename(slash_workspace), "team_a-1--")
+
+      assert :ok = Workspace.remove_issue_workspaces(slash_issue)
+      refute File.exists?(slash_workspace)
+      assert File.exists?(underscore_workspace)
+    after
+      File.rm_rf(workspace_root)
+    end
+  end
+
   test "workspace reuses existing issue directory without deleting local changes" do
     workspace_root =
       Path.join(
@@ -295,20 +323,20 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert :ok = Workspace.remove_issue_workspaces(nil)
   end
 
-  test "linear issue helpers" do
+  test "tracker issue helpers" do
     issue = %Issue{
       id: "abc",
       labels: ["frontend", "infra"],
-      assigned_to_worker: false
+      dispatchable: false
     }
 
     assert Issue.label_names(issue) == ["frontend", "infra"]
     assert issue.labels == ["frontend", "infra"]
-    refute issue.assigned_to_worker
+    refute issue.dispatchable
   end
 
-  test "linear issue routing requires every configured label" do
-    issue = %Issue{labels: [" Symphony ", "JavaScript"], assigned_to_worker: true}
+  test "tracker issue routing requires every configured label" do
+    issue = %Issue{labels: [" Symphony ", "JavaScript"], dispatchable: true}
 
     assert Issue.routable?(issue, [])
     assert Issue.routable?(issue, ["symphony"])
@@ -316,7 +344,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     refute Issue.routable?(issue, ["symph"])
     refute Issue.routable?(issue, [" "])
     refute Issue.routable?(issue, ["symphony", "security"])
-    refute Issue.routable?(%{issue | assigned_to_worker: false}, ["symphony"])
+    refute Issue.routable?(%{issue | dispatchable: false}, ["symphony"])
   end
 
   test "linear client normalizes blockers from inverse relations" do
@@ -332,7 +360,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       "assignee" => %{
         "id" => "user-1"
       },
-      "labels" => %{"nodes" => [%{"name" => "Backend"}]},
+      "labels" => %{"nodes" => [%{"name" => "Backend"}, %{"name" => " backend "}, %{"name" => " "}]},
       "inverseRelations" => %{
         "nodes" => [
           %{
@@ -361,10 +389,44 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert issue.blocked_by == [%{id: "issue-2", identifier: "MT-2", state: "In Progress"}]
     assert issue.labels == ["backend"]
+    assert issue.native_ref == nil
     assert issue.priority == 2
     assert issue.state == "Todo"
     assert issue.assignee_id == "user-1"
-    assert issue.assigned_to_worker
+    refute issue.dispatchable
+  end
+
+  test "linear client rejects malformed issues instead of returning invalid scheduler records" do
+    assert Client.normalize_issue_for_test(
+             %{
+               "id" => "issue-empty-title",
+               "identifier" => "MT-EMPTY",
+               "title" => " ",
+               "state" => %{"name" => "Todo"}
+             },
+             nil
+           ) == nil
+
+    graphql_fun = fn _query, _variables ->
+      {:ok,
+       %{
+         "data" => %{
+           "issues" => %{
+             "nodes" => [
+               %{
+                 "id" => "issue-empty-title",
+                 "identifier" => "MT-EMPTY",
+                 "title" => " ",
+                 "state" => %{"name" => "Todo"}
+               }
+             ]
+           }
+         }
+       }}
+    end
+
+    assert {:error, :linear_unknown_payload} =
+             Client.fetch_issues_by_ids_for_test(["issue-empty-title"], graphql_fun)
   end
 
   test "linear client marks explicitly unassigned issues as not routed to worker" do
@@ -380,7 +442,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     issue = Client.normalize_issue_for_test(raw_issue, "user-1")
 
-    refute issue.assigned_to_worker
+    refute issue.dispatchable
   end
 
   test "linear client pagination merge helper preserves issue ordering" do
@@ -431,14 +493,29 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       {:ok, body}
     end
 
-    assert {:ok, issues} = Client.fetch_issue_states_by_ids_for_test(issue_ids, graphql_fun)
+    assert {:ok, issues} = Client.fetch_issues_by_ids_for_test(issue_ids, graphql_fun)
 
     assert Enum.map(issues, & &1.id) == issue_ids
 
-    assert_receive {:fetch_issue_states_page, query, %{ids: ^first_batch_ids, first: 50, relationFirst: 50}}
-    assert query =~ "SymphonyLinearIssuesById"
+    assert_receive {:fetch_issue_states_page, query,
+                    %{
+                      ids: ^first_batch_ids,
+                      projectSlug: "test-project",
+                      first: 50,
+                      relationFirst: 50
+                    }}
 
-    assert_receive {:fetch_issue_states_page, ^query, %{ids: ^second_batch_ids, first: 5, relationFirst: 50}}
+    assert query =~ "SymphonyLinearIssuesById"
+    assert query =~ "projectSlug"
+    assert query =~ "slugId"
+
+    assert_receive {:fetch_issue_states_page, ^query,
+                    %{
+                      ids: ^second_batch_ids,
+                      projectSlug: "test-project",
+                      first: 5,
+                      relationFirst: 50
+                    }}
   end
 
   test "linear client logs response bodies for non-200 graphql responses" do
@@ -468,6 +545,26 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert log =~ "Linear GraphQL request failed status=400"
     assert log =~ ~s(body=%{"errors" => [%{"extensions" => %{"code" => "BAD_USER_INPUT"})
     assert log =~ "Variable \\\"$ids\\\" got invalid value"
+  end
+
+  test "linear graphql honors a bound tracker-settings snapshot" do
+    parent = self()
+
+    assert {:ok, %{"data" => %{"viewer" => %{"id" => "viewer-bound"}}}} =
+             Client.graphql(
+               "query Viewer { viewer { id } }",
+               %{},
+               tracker_settings: %{
+                 api_key: "bound-token",
+                 endpoint: "https://bound.example.test/graphql"
+               },
+               request_fun: fn payload, headers ->
+                 send(parent, {:bound_graphql_request, payload, headers})
+                 {:ok, %{status: 200, body: %{"data" => %{"viewer" => %{"id" => "viewer-bound"}}}}}
+               end
+             )
+
+    assert_receive {:bound_graphql_request, %{"query" => "query Viewer { viewer { id } }"}, [{"Authorization", "bound-token"}, {"Content-Type", "application/json"}]}
   end
 
   test "orchestrator sorts dispatch by priority then oldest created_at" do
@@ -508,7 +605,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert Enum.map(sorted, & &1.identifier) == ["MT-200", "MT-201", "MT-199"]
   end
 
-  test "todo issue with non-terminal blocker is not dispatch-eligible" do
+  test "provider-marked blocked issue is not dispatch-eligible" do
     state = %Orchestrator.State{
       max_concurrent_agents: 3,
       running: %{},
@@ -522,6 +619,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       identifier: "MT-1001",
       title: "Blocked work",
       state: "Todo",
+      dispatchable: false,
       blocked_by: [%{id: "blocker-1", identifier: "MT-1002", state: "In Progress"}]
     }
 
@@ -544,7 +642,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       identifier: "MT-1007",
       title: "Owned elsewhere",
       state: "Todo",
-      assigned_to_worker: false
+      dispatchable: false
     }
 
     refute Orchestrator.should_dispatch_issue_for_test(issue, state)
@@ -568,14 +666,15 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       identifier: "MT-1008",
       title: "Not opted in",
       state: "Todo",
-      labels: ["symphony"]
+      labels: ["symphony"],
+      dispatchable: true
     }
 
     refute Orchestrator.should_dispatch_issue_for_test(issue, state)
     assert Orchestrator.should_dispatch_issue_for_test(%{issue | labels: ["Symphony", "JavaScript"]}, state)
   end
 
-  test "todo issue with terminal blockers remains dispatch-eligible" do
+  test "provider-marked ready issue remains dispatch-eligible" do
     state = %Orchestrator.State{
       max_concurrent_agents: 3,
       running: %{},
@@ -589,13 +688,14 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       identifier: "MT-1003",
       title: "Ready work",
       state: "Todo",
-      blocked_by: [%{id: "blocker-2", identifier: "MT-1004", state: "Closed"}]
+      blocked_by: [%{id: "blocker-2", identifier: "MT-1004", state: "Closed"}],
+      dispatchable: true
     }
 
     assert Orchestrator.should_dispatch_issue_for_test(issue, state)
   end
 
-  test "dispatch revalidation skips stale todo issue once a non-terminal blocker appears" do
+  test "dispatch revalidation skips an issue when provider routing changes" do
     stale_issue = %Issue{
       id: "blocked-2",
       identifier: "MT-1005",
@@ -609,6 +709,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       identifier: "MT-1005",
       title: "Stale blocked work",
       state: "Todo",
+      dispatchable: false,
       blocked_by: [%{id: "blocker-3", identifier: "MT-1006", state: "In Progress"}]
     }
 
@@ -979,8 +1080,47 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     config = Config.settings!()
     assert config.tracker.api_key == api_key
+    assert config.tracker.secret_environment_names == ["LINEAR_API_KEY", api_key_env_var]
     assert config.workspace.root == Path.expand(workspace_root)
     assert config.codex.command == "#{codex_bin} app-server"
+  end
+
+  test "schema preserves adapter-owned provider config while keeping linear aliases compatible" do
+    assert {:ok, settings} =
+             Schema.parse(%{
+               tracker: %{
+                 kind: "linear",
+                 provider: %{
+                   endpoint: "https://linear.example.test/graphql",
+                   api_key: "provider-token",
+                   project_slug: "provider-project",
+                   extra: %{team: "platform"}
+                 }
+               }
+             })
+
+    assert settings.tracker.endpoint == "https://linear.example.test/graphql"
+    assert settings.tracker.api_key == "provider-token"
+    assert settings.tracker.project_slug == "provider-project"
+    assert settings.tracker.secret_environment_names == ["LINEAR_API_KEY"]
+
+    assert settings.tracker.provider == %{
+             "endpoint" => "https://linear.example.test/graphql",
+             "api_key" => "provider-token",
+             "project_slug" => "provider-project",
+             "assignee" => nil,
+             "extra" => %{"team" => "platform"}
+           }
+  end
+
+  test "schema does not inject linear defaults before an adapter is selected" do
+    assert {:ok, settings} = Schema.parse(%{tracker: %{kind: "future-tracker"}})
+
+    assert settings.tracker.endpoint == nil
+    assert settings.tracker.api_key == nil
+    assert settings.tracker.active_states == nil
+    assert settings.tracker.terminal_states == nil
+    assert settings.tracker.provider == %{}
   end
 
   test "config no longer resolves legacy env: references" do
@@ -1056,7 +1196,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert Schema.normalize_state_limits(nil) == %{}
 
-    assert Schema.normalize_state_limits(%{"In Progress" => 2, todo: 1}) == %{
+    assert Schema.normalize_state_limits(%{" In Progress " => 2, todo: 1}) == %{
              "todo" => 1,
              "in progress" => 2
            }
@@ -1069,6 +1209,15 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert changeset.errors == [
              limits: {"state names must not be blank", []},
              limits: {"limits must be positive integers", []}
+           ]
+
+    whitespace_state_changeset =
+      {%{}, %{limits: :map}}
+      |> Changeset.cast(%{limits: %{"   " => 1}}, [:limits])
+      |> Schema.validate_state_limits(:limits)
+
+    assert whitespace_state_changeset.errors == [
+             limits: {"state names must not be blank", []}
            ]
   end
 
@@ -1096,7 +1245,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert {:ok, settings} =
              Schema.parse(%{
-               tracker: %{api_key: "$#{empty_secret_env}"},
+               tracker: %{kind: "linear", api_key: "$#{empty_secret_env}"},
                workspace: %{root: "$#{missing_workspace_env}"},
                codex: %{approval_policy: %{reject: %{sandbox_approval: true}}}
              })
@@ -1110,7 +1259,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert {:ok, settings} =
              Schema.parse(%{
-               tracker: %{api_key: "$#{missing_secret_env}"},
+               tracker: %{kind: "linear", api_key: "$#{missing_secret_env}"},
                workspace: %{root: ""}
              })
 


### PR DESCRIPTION
#### Context

Symphony's scheduler was coupled to Linear types, reads, and mutations, making a second ticketing system require core orchestration changes.

#### TL;DR

*Introduce a generic tracker boundary while keeping Linear as the first adapter.*

#### Summary

- Normalize scheduler inputs through `Tracker.Issue` and two read operations.
- Keep Linear GraphQL mutations in a session-bound provider-native tool.
- Move provider config under `tracker.provider` with legacy Linear aliases.
- Make SPEC generic and document Linear's concrete adapter profile.
- Harden secret isolation, bound config snapshots, and provider validation.
- Use collision-resistant workspace keys as a clean cut, without migration code.

#### Alternatives

- A lowest-common-denominator write API was rejected because it would leak provider semantics or discard useful capabilities.
- A plugin system and full multi-provider rollout were deferred until a second adapter proves the smallest useful boundary.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/dynamic_tool_test.exs test/symphony_elixir/extensions_test.exs test/symphony_elixir/workspace_and_config_test.exs test/symphony_elixir/app_server_test.exs`
- [x] No-context SPEC probes: TypeScript 6/6, Python 6/6, and Go passed.
- [x] Live Linear smoke: local daemon processed FST-5 to Done, wrote one comment, and cleaned its workspace.
