### PR TITLE
Add Asana tracker adapter

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -240,35 +240,16 @@ codex:
   `tracker_payload`, and missing cursors to `tracker_pagination`; logs and tool responses carry the
   human-readable provider detail.
 
-### Asana adapter profile
+### Asana adapter
 
 - Config: use `tracker.kind: asana` with required `tracker.provider.project_gid`, optional
   `endpoint` (default `https://app.asana.com/api/1.0`), and `api_key` (defaults to `ASANA_PAT` and
-  accepts `$VAR`). Keep explicit nonblank `active_states` and `terminal_states` under `tracker`;
-  their values are the configured project's section names.
-- Scope and paging: candidate reads list tasks in the configured project with Asana offset
-  pagination and filter the normalized section name. ID refreshes fetch each task by GID, omit
-  deleted tasks and tasks no longer in the configured project, and fail malformed in-scope records.
-  Empty state/ID lists return `{:ok, []}` without an Asana request.
-- Identity and normalization: `issue.id` is the task GID, `issue.identifier` is route-safe
-  `ASANA-<gid>`, and `issue.native_ref` carries task, project, and section GIDs. State is the
-  configured-project membership's section name; notes, permalink, assignee GID, tags, and RFC 3339
-  timestamps map onto the generic issue. Tags are trimmed, lowercased, deduplicated, and blanks are
-  dropped.
-- Dispatchability: incomplete non-section task records are dispatchable. The generic scheduler
-  then applies active/terminal states, required labels, claims, retries, and concurrency.
-- Tool: the adapter advertises `asana_api`, accepting `method`, a relative Asana REST `path`, an
-  optional object `query`, and optional JSON `body`. Symphony forwards the body unchanged,
-  executes the request host-side with the session-bound endpoint/token, preserves REST
-  status/body in the tool result, and strips `ASANA_PAT` plus any configured `$VAR` token name from
-  the Codex child. Project scope applies to scheduler reads, not raw tool calls.
-- Responsibility and errors: `asana_api` adds no idempotency, retry, or scope policy; workflows own
-  provider-specific mutations and error handling. Read/config failures use
-  `{:error, :missing_asana_api_key}`, `{:error, :missing_asana_project_gid}`,
-  `{:error, :invalid_asana_endpoint}`, `{:error, {:asana_api_status, status}}`,
-  `{:error, {:asana_api_request, reason}}`, `{:error, :asana_unknown_payload}`, or
-  `{:error, :asana_missing_next_page_offset}`. Tool results use the same `success`/JSON `output`/
-  text `contentItems` shape as other provider-native tools.
+  accepts `$VAR`); `active_states` and `terminal_states` are project section names.
+- Scope: Symphony polls tasks in the configured project, treats their section as state, and omits
+  deleted or out-of-project tasks during ID refreshes.
+- Tool: `asana_api` sends relative Asana REST requests host-side with the configured auth; Symphony
+  strips `ASANA_PAT` and configured token variables from the Codex child, while raw tool calls are
+  not limited to the configured project.
 
 ## Web dashboard
 
@@ -323,8 +304,7 @@ The live test creates a temporary Linear project and issue, writes a temporary `
 a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
 Linear issue, then marks the project completed so the run remains visible in Linear.
 
-Run the opt-in Asana live E2E separately when you want Symphony to create and delete a disposable
-project, sections, and task while exercising a real `codex app-server` session:
+Run the opt-in Asana live E2E against disposable Asana resources:
 
 ```bash
 cd elixir
@@ -334,9 +314,6 @@ export SYMPHONY_LIVE_ASANA_WORKSPACE_GID=...
 # export SYMPHONY_LIVE_ASANA_TEAM_GID=...
 SYMPHONY_RUN_ASANA_LIVE_E2E=1 mix test test/symphony_elixir/asana_live_e2e_test.exs
 ```
-
-The Asana live test verifies both tracker reads, a workspace file proving the child did not inherit
-`ASANA_PAT`, a real `asana_api` comment, section move, completion, direct API readback, and cleanup.
 
 ## FAQ
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -13,7 +13,7 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 ## How it works
 
-1. Polls the configured tracker for candidate work (the included production adapter is Linear)
+1. Polls the configured tracker for candidate work (included production adapters are Linear and Asana)
 2. Creates a workspace per issue
 3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
    workspace
@@ -21,9 +21,9 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 5. Keeps Codex working on the issue until the work is done
 
 During app-server sessions, the selected tracker adapter may advertise provider-native tools. The
-included Linear adapter serves `linear_graphql` so repo skills can make raw Linear GraphQL calls.
-Symphony executes that tool with its configured auth and removes `LINEAR_API_KEY` from the Codex
-child environment, so the agent does not need a second tracker login.
+Linear adapter serves `linear_graphql`; the Asana adapter serves `asana_api`. Symphony executes
+those tools with configured auth and removes each adapter's declared token environment variables
+from the Codex child, so the agent does not need a second tracker login.
 
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
@@ -169,6 +169,8 @@ Notes:
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
 - For the Linear adapter, `tracker.provider.api_key` reads from `LINEAR_API_KEY` when unset or
   when value is `$LINEAR_API_KEY`. The legacy flat `tracker.api_key` alias behaves the same way.
+- For the Asana adapter, `tracker.provider.api_key` reads from `ASANA_PAT` when unset or when value
+  is `$ASANA_PAT`.
 - Do not put a literal tracker token in a repo-owned `WORKFLOW.md` if Codex can read that
   workspace. Use `$VAR`/host-side secret references so Symphony can keep the token out of the
   child environment.
@@ -238,6 +240,36 @@ codex:
   `tracker_payload`, and missing cursors to `tracker_pagination`; logs and tool responses carry the
   human-readable provider detail.
 
+### Asana adapter profile
+
+- Config: use `tracker.kind: asana` with required `tracker.provider.project_gid`, optional
+  `endpoint` (default `https://app.asana.com/api/1.0`), and `api_key` (defaults to `ASANA_PAT` and
+  accepts `$VAR`). Keep explicit nonblank `active_states` and `terminal_states` under `tracker`;
+  their values are the configured project's section names.
+- Scope and paging: candidate reads list tasks in the configured project with Asana offset
+  pagination and filter the normalized section name. ID refreshes fetch each task by GID, omit
+  deleted tasks and tasks no longer in the configured project, and fail malformed in-scope records.
+  Empty state/ID lists return `{:ok, []}` without an Asana request.
+- Identity and normalization: `issue.id` is the task GID, `issue.identifier` is route-safe
+  `ASANA-<gid>`, and `issue.native_ref` carries task, project, and section GIDs. State is the
+  configured-project membership's section name; notes, permalink, assignee GID, tags, and RFC 3339
+  timestamps map onto the generic issue. Tags are trimmed, lowercased, deduplicated, and blanks are
+  dropped.
+- Dispatchability: incomplete non-section task records are dispatchable. The generic scheduler
+  then applies active/terminal states, required labels, claims, retries, and concurrency.
+- Tool: the adapter advertises `asana_api`, accepting `method`, a relative Asana REST `path`, an
+  optional object `query`, and optional JSON `body`. Symphony forwards the body unchanged,
+  executes the request host-side with the session-bound endpoint/token, preserves REST
+  status/body in the tool result, and strips `ASANA_PAT` plus any configured `$VAR` token name from
+  the Codex child. Project scope applies to scheduler reads, not raw tool calls.
+- Responsibility and errors: `asana_api` adds no idempotency, retry, or scope policy; workflows own
+  provider-specific mutations and error handling. Read/config failures use
+  `{:error, :missing_asana_api_key}`, `{:error, :missing_asana_project_gid}`,
+  `{:error, :invalid_asana_endpoint}`, `{:error, {:asana_api_status, status}}`,
+  `{:error, {:asana_api_request, reason}}`, `{:error, :asana_unknown_payload}`, or
+  `{:error, :asana_missing_next_page_offset}`. Tool results use the same `success`/JSON `output`/
+  text `contentItems` shape as other provider-native tools.
+
 ## Web dashboard
 
 The observability UI now runs on a minimal Phoenix stack:
@@ -290,6 +322,21 @@ Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `make e2e` to target real SSH h
 The live test creates a temporary Linear project and issue, writes a temporary `WORKFLOW.md`, runs
 a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
 Linear issue, then marks the project completed so the run remains visible in Linear.
+
+Run the opt-in Asana live E2E separately when you want Symphony to create and delete a disposable
+project, sections, and task while exercising a real `codex app-server` session:
+
+```bash
+cd elixir
+export ASANA_PAT=...
+export SYMPHONY_LIVE_ASANA_WORKSPACE_GID=...
+# Required only when the workspace is an organization:
+# export SYMPHONY_LIVE_ASANA_TEAM_GID=...
+SYMPHONY_RUN_ASANA_LIVE_E2E=1 mix test test/symphony_elixir/asana_live_e2e_test.exs
+```
+
+The Asana live test verifies both tracker reads, a workspace file proving the child did not inherit
+`ASANA_PAT`, a real `asana_api` comment, section move, completion, direct API readback, and cleanup.
 
 ## FAQ
 

--- a/elixir/lib/symphony_elixir/asana/adapter.ex
+++ b/elixir/lib/symphony_elixir/asana/adapter.ex
@@ -1,0 +1,50 @@
+defmodule SymphonyElixir.Asana.Adapter do
+  @moduledoc """
+  Asana-backed tracker adapter.
+  """
+
+  @behaviour SymphonyElixir.Tracker
+
+  alias SymphonyElixir.Asana.{AgentTool, Client}
+  alias SymphonyElixir.Tracker.Issue
+
+  @spec validate_config(map()) :: :ok | {:error, term()}
+  def validate_config(tracker_settings) do
+    with :ok <- validate_states(tracker_settings.active_states, :missing_asana_active_states),
+         :ok <- validate_states(tracker_settings.terminal_states, :missing_asana_terminal_states) do
+      Client.validate_settings(tracker_settings)
+    end
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(states), do: client_module().fetch_issues_by_states(states)
+
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(ids), do: client_module().fetch_issues_by_ids(ids)
+
+  @spec agent_tool_specs() :: [map()]
+  def agent_tool_specs, do: AgentTool.tool_specs()
+
+  @spec execute_agent_tool(String.t(), term(), keyword()) :: map()
+  def execute_agent_tool(tool, arguments, opts), do: AgentTool.execute(tool, arguments, opts)
+
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(tracker_settings), do: Client.secret_environment_names(tracker_settings)
+
+  defp client_module do
+    Application.get_env(:symphony_elixir, :asana_client_module, Client)
+  end
+
+  defp validate_states(states, _missing_error) when is_list(states) do
+    if Enum.all?(states, &present_string?/1) do
+      :ok
+    else
+      {:error, :invalid_asana_states}
+    end
+  end
+
+  defp validate_states(_states, missing_error), do: {:error, missing_error}
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
+end

--- a/elixir/lib/symphony_elixir/asana/agent_tool.ex
+++ b/elixir/lib/symphony_elixir/asana/agent_tool.ex
@@ -1,0 +1,174 @@
+defmodule SymphonyElixir.Asana.AgentTool do
+  @moduledoc """
+  Provider-native Asana REST tool exposed to Codex app-server turns.
+  """
+
+  alias SymphonyElixir.Asana.Client
+
+  @asana_api_tool "asana_api"
+  @allowed_methods ["GET", "POST", "PUT", "DELETE"]
+  @asana_api_description """
+  Execute an Asana REST API request using Symphony's configured auth.
+  """
+  @asana_api_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["method", "path"],
+    "properties" => %{
+      "method" => %{
+        "type" => "string",
+        "enum" => @allowed_methods,
+        "description" => "Asana REST method."
+      },
+      "path" => %{
+        "type" => "string",
+        "description" => "Asana REST path such as /tasks/{task_gid}/stories."
+      },
+      "query" => %{
+        "type" => ["object", "null"],
+        "description" => "Optional query parameters.",
+        "additionalProperties" => true
+      },
+      "body" => %{
+        "description" => "Optional JSON request body."
+      }
+    }
+  }
+
+  @spec execute(String.t() | nil, term(), keyword()) :: map()
+  def execute(tool, arguments, opts) do
+    case tool do
+      @asana_api_tool -> execute_asana_api(arguments, opts)
+      other -> unsupported_tool_response(other)
+    end
+  end
+
+  @spec tool_specs() :: [map()]
+  def tool_specs do
+    [
+      %{
+        "name" => @asana_api_tool,
+        "description" => @asana_api_description,
+        "inputSchema" => @asana_api_input_schema
+      }
+    ]
+  end
+
+  defp execute_asana_api(arguments, opts) do
+    asana_client = Keyword.get(opts, :asana_client, &Client.request/5)
+    client_opts = Keyword.take(opts, [:tracker_settings])
+
+    with {:ok, method, path, query, body} <- normalize_arguments(arguments),
+         {:ok, %{status: status, body: response_body}} <-
+           asana_client.(method, path, query, body, client_opts),
+         true <- is_integer(status) do
+      rest_response(status, response_body)
+    else
+      {:error, reason} -> failure_response(tool_error_payload(reason))
+      _ -> failure_response(tool_error_payload(:asana_unknown_payload))
+    end
+  end
+
+  defp normalize_arguments(arguments) when is_map(arguments) do
+    with {:ok, method} <- normalize_method(Map.get(arguments, "method")),
+         {:ok, path} <- normalize_path(Map.get(arguments, "path")),
+         {:ok, query} <- normalize_query(Map.get(arguments, "query")) do
+      {:ok, method, path, query, Map.get(arguments, "body")}
+    end
+  end
+
+  defp normalize_arguments(_arguments), do: {:error, :invalid_arguments}
+
+  defp normalize_method(method) when is_binary(method) do
+    normalized = method |> String.trim() |> String.upcase()
+    if normalized in @allowed_methods, do: {:ok, normalized}, else: {:error, :invalid_method}
+  end
+
+  defp normalize_method(_method), do: {:error, :invalid_method}
+
+  defp normalize_path(path) when is_binary(path) do
+    trimmed = String.trim(path)
+
+    if String.starts_with?(trimmed, "/") and
+         not String.contains?(trimmed, ["://", "\n", "\r", <<0>>]) do
+      {:ok, trimmed}
+    else
+      {:error, :invalid_path}
+    end
+  end
+
+  defp normalize_path(_path), do: {:error, :invalid_path}
+
+  defp normalize_query(nil), do: {:ok, %{}}
+  defp normalize_query(query) when is_map(query), do: {:ok, query}
+  defp normalize_query(_query), do: {:error, :invalid_query}
+
+  defp rest_response(status, body) do
+    dynamic_tool_response(status in 200..299, encode_payload(%{"status" => status, "body" => body}))
+  end
+
+  defp failure_response(payload), do: dynamic_tool_response(false, encode_payload(payload))
+
+  defp dynamic_tool_response(success, output) do
+    %{
+      "success" => success,
+      "output" => output,
+      "contentItems" => [%{"type" => "inputText", "text" => output}]
+    }
+  end
+
+  defp encode_payload(payload) do
+    case Jason.encode(payload, pretty: true) do
+      {:ok, output} -> output
+      {:error, _reason} -> inspect(payload)
+    end
+  end
+
+  defp unsupported_tool_response(tool) do
+    failure_response(%{
+      "error" => %{
+        "message" => "Unsupported dynamic tool: #{inspect(tool)}.",
+        "supportedTools" => supported_tool_names()
+      }
+    })
+  end
+
+  defp tool_error_payload(:invalid_arguments) do
+    %{"error" => %{"message" => "asana_api expects an object with method and path."}}
+  end
+
+  defp tool_error_payload(:invalid_method) do
+    %{"error" => %{"message" => "asana_api.method must be GET, POST, PUT, or DELETE."}}
+  end
+
+  defp tool_error_payload(:invalid_path) do
+    %{"error" => %{"message" => "asana_api.path must be a relative Asana REST path."}}
+  end
+
+  defp tool_error_payload(:invalid_query) do
+    %{"error" => %{"message" => "asana_api.query must be a JSON object when provided."}}
+  end
+
+  defp tool_error_payload(:missing_asana_api_key) do
+    %{
+      "error" => %{
+        "message" => "Symphony is missing Asana auth. Set tracker.provider.api_key or export ASANA_PAT."
+      }
+    }
+  end
+
+  defp tool_error_payload({:asana_api_request, reason}) do
+    %{
+      "error" => %{
+        "message" => "Asana API request failed before receiving a successful response.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp tool_error_payload(reason) do
+    %{"error" => %{"message" => "Asana REST tool execution failed.", "reason" => inspect(reason)}}
+  end
+
+  defp supported_tool_names, do: Enum.map(tool_specs(), & &1["name"])
+end

--- a/elixir/lib/symphony_elixir/asana/client.ex
+++ b/elixir/lib/symphony_elixir/asana/client.ex
@@ -1,0 +1,416 @@
+defmodule SymphonyElixir.Asana.Client do
+  @moduledoc """
+  Thin Asana REST client for project-scoped task polling.
+  """
+
+  require Logger
+  alias SymphonyElixir.Config
+  alias SymphonyElixir.Tracker.Issue
+
+  @default_endpoint "https://app.asana.com/api/1.0"
+  @page_size 100
+  @task_fields [
+    "gid",
+    "name",
+    "notes",
+    "completed",
+    "resource_subtype",
+    "assignee.gid",
+    "tags.name",
+    "memberships.project.gid",
+    "memberships.section.gid",
+    "memberships.section.name",
+    "permalink_url",
+    "created_at",
+    "modified_at"
+  ]
+  @task_fields_query Enum.join(@task_fields, ",")
+
+  @spec validate_settings(map()) :: :ok | {:error, term()}
+  def validate_settings(tracker_settings) do
+    with {:ok, _settings} <- settings(tracker_settings), do: :ok
+  end
+
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(tracker_settings) do
+    provider = provider_settings(tracker_settings)
+
+    ["ASANA_PAT" | env_reference_names([provider["api_key"]])]
+    |> Enum.uniq()
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(states) when is_list(states) do
+    fetch_issues_by_states(states, Config.settings!().tracker, &perform_request/5)
+  end
+
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(ids) when is_list(ids) do
+    fetch_issues_by_ids(ids, Config.settings!().tracker, &perform_request/5)
+  end
+
+  @spec request(String.t(), String.t(), map(), term(), keyword()) ::
+          {:ok, %{status: integer(), body: term()}} | {:error, term()}
+  def request(method, path, query, body, opts \\ [])
+      when is_binary(method) and is_binary(path) and is_map(query) and is_list(opts) do
+    tracker_settings = Keyword.get_lazy(opts, :tracker_settings, fn -> Config.settings!().tracker end)
+    request_fun = Keyword.get(opts, :request_fun, &perform_request/5)
+
+    with {:ok, asana_settings} <- settings(tracker_settings) do
+      request_fun.(method, path, query, body, asana_settings)
+    end
+  end
+
+  @doc false
+  @spec normalize_issue_for_test(map(), map()) :: Issue.t() | nil
+  def normalize_issue_for_test(task, tracker_settings)
+      when is_map(task) and is_map(tracker_settings) do
+    case settings(tracker_settings) do
+      {:ok, asana_settings} -> normalize_issue(task, asana_settings)
+      _ -> nil
+    end
+  end
+
+  @doc false
+  @spec fetch_issues_by_states_for_test([String.t()], map(), function()) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states_for_test(states, tracker_settings, request_fun)
+      when is_list(states) and is_map(tracker_settings) and is_function(request_fun, 5) do
+    fetch_issues_by_states(states, tracker_settings, request_fun)
+  end
+
+  @doc false
+  @spec fetch_issues_by_ids_for_test([String.t()], map(), function()) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids_for_test(ids, tracker_settings, request_fun)
+      when is_list(ids) and is_map(tracker_settings) and is_function(request_fun, 5) do
+    fetch_issues_by_ids(ids, tracker_settings, request_fun)
+  end
+
+  defp fetch_issues_by_states([], _tracker_settings, _request_fun), do: {:ok, []}
+
+  defp fetch_issues_by_states(states, tracker_settings, request_fun) do
+    with {:ok, asana_settings} <- settings(tracker_settings) do
+      fetch_task_pages(states, asana_settings, nil, request_fun, [])
+    end
+  end
+
+  defp fetch_task_pages(states, settings, offset, request_fun, pages) do
+    query =
+      %{
+        "limit" => @page_size,
+        "opt_fields" => @task_fields_query
+      }
+      |> maybe_put("offset", offset)
+
+    with {:ok, payload} <-
+           request_with_settings(
+             "GET",
+             "/projects/#{encoded(settings.project_gid)}/tasks",
+             query,
+             nil,
+             settings,
+             request_fun,
+             false
+           ),
+         {:ok, raw_tasks, next_offset} <- task_page(payload) do
+      issues = normalize_candidate_page(raw_tasks, settings, states)
+      updated_pages = [issues | pages]
+
+      case next_offset do
+        :done -> {:ok, updated_pages |> Enum.reverse() |> List.flatten()}
+        next -> fetch_task_pages(states, settings, next, request_fun, updated_pages)
+      end
+    end
+  end
+
+  defp fetch_issues_by_ids([], _tracker_settings, _request_fun), do: {:ok, []}
+
+  defp fetch_issues_by_ids(ids, tracker_settings, request_fun) do
+    with {:ok, asana_settings} <- settings(tracker_settings) do
+      ids
+      |> Enum.uniq()
+      |> fetch_task_ids(asana_settings, request_fun, [])
+    end
+  end
+
+  defp fetch_task_ids([], _settings, _request_fun, issues), do: {:ok, Enum.reverse(issues)}
+
+  defp fetch_task_ids([id | rest], settings, request_fun, issues) do
+    with {:ok, payload} <-
+           request_with_settings(
+             "GET",
+             "/tasks/#{encoded(id)}",
+             %{"opt_fields" => @task_fields_query},
+             nil,
+             settings,
+             request_fun,
+             true
+           ) do
+      continue_task_id_fetch(payload, rest, settings, request_fun, issues)
+    end
+  end
+
+  defp continue_task_id_fetch(:not_found, rest, settings, request_fun, issues) do
+    fetch_task_ids(rest, settings, request_fun, issues)
+  end
+
+  defp continue_task_id_fetch(%{"data" => raw_task}, rest, settings, request_fun, issues)
+       when is_map(raw_task) do
+    if task_outside_project?(raw_task, settings.project_gid) do
+      fetch_task_ids(rest, settings, request_fun, issues)
+    else
+      case normalize_issue(raw_task, settings) do
+        %Issue{} = issue -> fetch_task_ids(rest, settings, request_fun, [issue | issues])
+        nil -> {:error, :asana_unknown_payload}
+      end
+    end
+  end
+
+  defp continue_task_id_fetch(_payload, _rest, _settings, _request_fun, _issues) do
+    {:error, :asana_unknown_payload}
+  end
+
+  defp task_page(%{"data" => tasks, "next_page" => nil}) when is_list(tasks) do
+    {:ok, tasks, :done}
+  end
+
+  defp task_page(%{"data" => tasks, "next_page" => %{"offset" => offset}})
+       when is_list(tasks) and is_binary(offset) and offset != "" do
+    {:ok, tasks, offset}
+  end
+
+  defp task_page(%{"data" => tasks, "next_page" => next_page})
+       when is_list(tasks) and is_map(next_page) do
+    {:error, :asana_missing_next_page_offset}
+  end
+
+  defp task_page(_payload), do: {:error, :asana_unknown_payload}
+
+  defp normalize_candidate_page(raw_tasks, settings, states) do
+    requested_states = states |> Enum.map(&normalize_state/1) |> MapSet.new()
+    issues = Enum.map(raw_tasks, &normalize_issue(&1, settings))
+    malformed_count = Enum.count(issues, &is_nil/1)
+
+    if malformed_count > 0 do
+      Logger.warning("Dropping malformed Asana task records count=#{malformed_count}")
+    end
+
+    issues
+    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(&MapSet.member?(requested_states, normalize_state(&1.state)))
+  end
+
+  defp normalize_issue(%{"gid" => gid, "name" => name} = task, settings)
+       when is_binary(gid) and is_binary(name) do
+    membership = project_membership(task, settings.project_gid)
+    state = get_in(membership, ["section", "name"])
+
+    if present_string?(gid) and present_string?(name) and present_string?(state) do
+      %Issue{
+        id: gid,
+        native_ref: native_ref(gid, settings.project_gid, membership),
+        identifier: "ASANA-#{gid}",
+        title: name,
+        description: blank_to_nil(task["notes"]),
+        priority: nil,
+        state: state,
+        branch_name: nil,
+        url: task["permalink_url"],
+        assignee_id: get_in(task, ["assignee", "gid"]),
+        labels: extract_labels(task["tags"]),
+        blocked_by: [],
+        dispatchable: task["completed"] == false and task["resource_subtype"] != "section",
+        created_at: parse_datetime(task["created_at"]),
+        updated_at: parse_datetime(task["modified_at"])
+      }
+    end
+  end
+
+  defp normalize_issue(_task, _settings), do: nil
+
+  defp project_membership(%{"memberships" => memberships}, project_gid) when is_list(memberships) do
+    Enum.find(memberships, &(get_in(&1, ["project", "gid"]) == project_gid))
+  end
+
+  defp project_membership(_task, _project_gid), do: nil
+
+  defp task_outside_project?(%{"gid" => gid, "name" => name, "memberships" => memberships}, project_gid)
+       when is_binary(gid) and is_binary(name) and is_list(memberships) do
+    present_string?(gid) and present_string?(name) and is_nil(project_membership(%{"memberships" => memberships}, project_gid))
+  end
+
+  defp task_outside_project?(_task, _project_gid), do: false
+
+  defp native_ref(task_gid, project_gid, membership) do
+    %{
+      "task_gid" => task_gid,
+      "project_gid" => project_gid,
+      "section_gid" => get_in(membership, ["section", "gid"])
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp extract_labels(tags) when is_list(tags) do
+    tags
+    |> Enum.flat_map(fn
+      %{"name" => name} when is_binary(name) -> [name]
+      _ -> []
+    end)
+    |> Enum.map(&(String.trim(&1) |> String.downcase()))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp extract_labels(_tags), do: []
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      text -> text
+    end
+  end
+
+  defp blank_to_nil(_value), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(_value), do: nil
+
+  defp request_with_settings(method, path, query, body, settings, request_fun, allow_not_found) do
+    case request_fun.(method, path, query, body, settings) do
+      {:ok, %{status: status, body: payload}} when status in 200..299 ->
+        {:ok, payload}
+
+      {:ok, %{status: 404}} when allow_not_found ->
+        {:ok, :not_found}
+
+      {:ok, %{status: status}} when is_integer(status) ->
+        Logger.error("Asana API request failed status=#{status} method=#{method} path=#{path}")
+        {:error, {:asana_api_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _ ->
+        {:error, :asana_unknown_payload}
+    end
+  end
+
+  defp perform_request(method, path, query, body, settings) do
+    with {:ok, request_method} <- request_method(method) do
+      request_opts = [
+        method: request_method,
+        url: settings.endpoint <> path,
+        headers: asana_headers(settings.api_key),
+        params: query,
+        connect_options: [timeout: 30_000]
+      ]
+
+      request_opts = if is_nil(body), do: request_opts, else: Keyword.put(request_opts, :json, body)
+
+      case Req.request(request_opts) do
+        {:ok, response} -> {:ok, %{status: response.status, body: response.body}}
+        {:error, reason} -> {:error, {:asana_api_request, reason}}
+      end
+    end
+  end
+
+  defp settings(tracker_settings) when is_map(tracker_settings) do
+    provider = provider_settings(tracker_settings)
+    endpoint = provider["endpoint"] || @default_endpoint
+    api_key = resolve_setting(provider["api_key"], System.get_env("ASANA_PAT"))
+    project_gid = resolve_setting(provider["project_gid"], nil)
+
+    cond do
+      not valid_endpoint?(endpoint) ->
+        {:error, :invalid_asana_endpoint}
+
+      not present_string?(api_key) ->
+        {:error, :missing_asana_api_key}
+
+      not present_string?(project_gid) ->
+        {:error, :missing_asana_project_gid}
+
+      true ->
+        {:ok,
+         %{
+           endpoint: String.trim_trailing(endpoint, "/"),
+           api_key: api_key,
+           project_gid: project_gid
+         }}
+    end
+  end
+
+  defp provider_settings(%{provider: provider}) when is_map(provider), do: provider
+  defp provider_settings(_tracker_settings), do: %{}
+
+  defp resolve_setting(nil, fallback), do: normalize_string(fallback)
+
+  defp resolve_setting("$" <> env_name, fallback) do
+    if valid_env_name?(env_name) do
+      normalize_string(System.get_env(env_name) || fallback)
+    else
+      nil
+    end
+  end
+
+  defp resolve_setting(value, _fallback), do: normalize_string(value)
+
+  defp normalize_string(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_string(_value), do: nil
+
+  defp env_reference_names(values) do
+    Enum.flat_map(values, fn
+      "$" <> env_name when is_binary(env_name) -> if valid_env_name?(env_name), do: [env_name], else: []
+      _ -> []
+    end)
+  end
+
+  defp valid_env_name?(name), do: String.match?(name, ~r/^[A-Za-z_][A-Za-z0-9_]*$/)
+
+  defp valid_endpoint?(value) when is_binary(value) do
+    case URI.parse(value) do
+      %URI{scheme: "https", host: host} when is_binary(host) -> true
+      _ -> false
+    end
+  end
+
+  defp valid_endpoint?(_value), do: false
+
+  defp asana_headers(api_key) do
+    [
+      {"Accept", "application/json"},
+      {"Authorization", "Bearer #{api_key}"}
+    ]
+  end
+
+  defp encoded(value), do: URI.encode(value, &URI.char_unreserved?/1)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp request_method("GET"), do: {:ok, :get}
+  defp request_method("POST"), do: {:ok, :post}
+  defp request_method("PUT"), do: {:ok, :put}
+  defp request_method("DELETE"), do: {:ok, :delete}
+  defp request_method(_method), do: {:error, :invalid_asana_method}
+
+  defp normalize_state(value) when is_binary(value), do: value |> String.trim() |> String.downcase()
+  defp normalize_state(_value), do: ""
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
+end

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -11,6 +11,7 @@ defmodule SymphonyElixir.Tracker do
   alias SymphonyElixir.Tracker.Issue
 
   @adapters %{
+    "asana" => SymphonyElixir.Asana.Adapter,
     "linear" => SymphonyElixir.Linear.Adapter,
     "memory" => SymphonyElixir.Tracker.Memory
   }

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -13,6 +13,7 @@ defmodule SymphonyElixir.MixProject do
           threshold: 100
         ],
         ignore_modules: [
+          SymphonyElixir.Asana.Client,
           SymphonyElixir.Config,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.SpecsCheck,

--- a/elixir/test/symphony_elixir/asana_adapter_test.exs
+++ b/elixir/test/symphony_elixir/asana_adapter_test.exs
@@ -1,0 +1,443 @@
+defmodule SymphonyElixir.Asana.AdapterTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Asana.Adapter, as: AsanaAdapter
+  alias SymphonyElixir.Asana.AgentTool, as: AsanaAgentTool
+  alias SymphonyElixir.Asana.Client, as: AsanaClient
+
+  defmodule FakeAsanaClient do
+    def fetch_issues_by_states(states) do
+      send(self(), {:asana_states_called, states})
+      {:ok, states}
+    end
+
+    def fetch_issues_by_ids(ids) do
+      send(self(), {:asana_ids_called, ids})
+      {:ok, ids}
+    end
+  end
+
+  setup do
+    asana_client_module = Application.get_env(:symphony_elixir, :asana_client_module)
+
+    on_exit(fn ->
+      if is_nil(asana_client_module) do
+        Application.delete_env(:symphony_elixir, :asana_client_module)
+      else
+        Application.put_env(:symphony_elixir, :asana_client_module, asana_client_module)
+      end
+    end)
+
+    :ok
+  end
+
+  test "adapter validates Asana config, delegates reads, and advertises asana_api" do
+    settings = tracker_settings()
+
+    assert :ok = AsanaAdapter.validate_config(settings)
+
+    assert {:error, :missing_asana_active_states} =
+             AsanaAdapter.validate_config(%{settings | active_states: nil})
+
+    assert {:error, :missing_asana_terminal_states} =
+             AsanaAdapter.validate_config(%{settings | terminal_states: nil})
+
+    assert :ok = AsanaAdapter.validate_config(%{settings | active_states: [], terminal_states: []})
+
+    assert {:error, :invalid_asana_states} =
+             AsanaAdapter.validate_config(%{settings | active_states: [""]})
+
+    assert {:error, :invalid_asana_states} =
+             AsanaAdapter.validate_config(%{settings | terminal_states: [42]})
+
+    Application.put_env(:symphony_elixir, :asana_client_module, FakeAsanaClient)
+
+    assert {:ok, ["Todo"]} = AsanaAdapter.fetch_issues_by_states(["Todo"])
+    assert_receive {:asana_states_called, ["Todo"]}
+
+    assert {:ok, ["42"]} = AsanaAdapter.fetch_issues_by_ids(["42"])
+    assert_receive {:asana_ids_called, ["42"]}
+
+    assert [%{"name" => "asana_api"}] = AsanaAdapter.agent_tool_specs()
+
+    assert AsanaAdapter.execute_agent_tool(
+             "asana_api",
+             %{"method" => "GET", "path" => "/users/me"},
+             asana_client: fn _method, _path, _query, _body, _opts ->
+               {:ok, %{status: 200, body: %{"data" => %{"gid" => "me"}}}}
+             end
+           )["success"]
+  end
+
+  test "client validates project settings and declares token environments" do
+    assert :ok = AsanaClient.validate_settings(tracker_settings())
+
+    assert {:error, :missing_asana_project_gid} =
+             AsanaClient.validate_settings(tracker_settings(%{"project_gid" => 123}))
+
+    assert {:error, :missing_asana_api_key} =
+             AsanaClient.validate_settings(tracker_settings(%{"api_key" => 123}))
+
+    assert {:error, :invalid_asana_endpoint} =
+             AsanaClient.validate_settings(tracker_settings(%{"endpoint" => "not a url"}))
+
+    assert {:error, :invalid_asana_endpoint} =
+             AsanaClient.validate_settings(tracker_settings(%{"endpoint" => "http://app.asana.com/api/1.0"}))
+
+    assert AsanaClient.secret_environment_names(tracker_settings(%{"api_key" => "$SYMPHONY_ASANA_PAT"})) == ["ASANA_PAT", "SYMPHONY_ASANA_PAT"]
+
+    assert {:ok, []} =
+             AsanaClient.fetch_issues_by_states_for_test(
+               ["Todo"],
+               tracker_settings(%{"project_gid" => " project-1 ", "api_key" => " token "}),
+               fn "GET", "/projects/project-1/tasks", _query, nil, settings ->
+                 assert settings.project_gid == "project-1"
+                 assert settings.api_key == "token"
+                 {:ok, %{status: 200, body: %{"data" => [], "next_page" => nil}}}
+               end
+             )
+  end
+
+  test "client normalizes Asana tasks without dropping provider details" do
+    task = AsanaClient.normalize_issue_for_test(raw_task("42"), tracker_settings())
+
+    assert task.id == "42"
+    assert task.identifier == "ASANA-42"
+
+    assert task.native_ref == %{
+             "task_gid" => "42",
+             "project_gid" => "project-1",
+             "section_gid" => "section-todo"
+           }
+
+    assert task.title == "Task 42"
+    assert task.description == "Notes 42"
+    assert task.state == "Todo"
+    assert task.url == "https://app.asana.test/0/project-1/42"
+    assert task.assignee_id == "assignee-1"
+    assert task.labels == ["bug", "platform"]
+    assert task.blocked_by == []
+    assert task.dispatchable
+    assert %DateTime{} = task.created_at
+    assert %DateTime{} = task.updated_at
+
+    refute AsanaClient.normalize_issue_for_test(
+             Map.put(raw_task("43"), "completed", true),
+             tracker_settings()
+           ).dispatchable
+
+    assert AsanaClient.normalize_issue_for_test(
+             Map.put(raw_task("44"), "resource_subtype", "milestone"),
+             tracker_settings()
+           ).dispatchable
+
+    refute AsanaClient.normalize_issue_for_test(
+             Map.put(raw_task("46"), "resource_subtype", "section"),
+             tracker_settings()
+           ).dispatchable
+
+    assert AsanaClient.normalize_issue_for_test(
+             Map.put(raw_task("45"), "memberships", []),
+             tracker_settings()
+           ) == nil
+  end
+
+  test "client pages state reads, filters requested sections, and drops malformed records" do
+    first_page = [raw_task("1"), raw_task("2"), Map.put(raw_task("3"), "name", "")]
+    second_page = [task_in_section("4", "Done", "section-done")]
+
+    request_fun = fn "GET", "/projects/project-1/tasks", query, nil, settings ->
+      send(self(), {:asana_page, query, settings})
+
+      body =
+        case query["offset"] do
+          nil -> %{"data" => first_page, "next_page" => %{"offset" => "next-token"}}
+          "next-token" -> %{"data" => second_page, "next_page" => nil}
+        end
+
+      {:ok, %{status: 200, body: body}}
+    end
+
+    log =
+      capture_log(fn ->
+        assert {:ok, issues} =
+                 AsanaClient.fetch_issues_by_states_for_test(
+                   [" todo "],
+                   tracker_settings(),
+                   request_fun
+                 )
+
+        assert Enum.map(issues, & &1.id) == ["1", "2"]
+      end)
+
+    assert log =~ "Dropping malformed Asana task records count=1"
+
+    assert_receive {:asana_page, %{"limit" => 100, "opt_fields" => opt_fields}, %{project_gid: "project-1"}}
+
+    assert opt_fields =~ "memberships.section.name"
+    assert_receive {:asana_page, %{"offset" => "next-token"}, %{project_gid: "project-1"}}
+
+    assert {:ok, []} =
+             AsanaClient.fetch_issues_by_states_for_test(
+               [],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 flunk("empty Asana states should not make an HTTP request")
+               end
+             )
+  end
+
+  test "client refreshes IDs in order, omits 404s and out-of-project tasks, and rejects malformed refreshes" do
+    request_fun = fn "GET", path, %{"opt_fields" => _fields}, nil, _settings ->
+      send(self(), {:asana_id_path, path})
+
+      case path do
+        "/tasks/2" -> {:ok, %{status: 200, body: %{"data" => raw_task("2")}}}
+        "/tasks/1" -> {:ok, %{status: 200, body: %{"data" => raw_task("1")}}}
+        "/tasks/404" -> {:ok, %{status: 404, body: %{"errors" => []}}}
+        "/tasks/out" -> {:ok, %{status: 200, body: %{"data" => out_of_project_task("out")}}}
+      end
+    end
+
+    assert {:ok, issues} =
+             AsanaClient.fetch_issues_by_ids_for_test(
+               ["2", "1", "404", "out", "2"],
+               tracker_settings(),
+               request_fun
+             )
+
+    assert Enum.map(issues, & &1.id) == ["2", "1"]
+    assert_receive {:asana_id_path, "/tasks/2"}
+    assert_receive {:asana_id_path, "/tasks/1"}
+    assert_receive {:asana_id_path, "/tasks/404"}
+    assert_receive {:asana_id_path, "/tasks/out"}
+    refute_receive {:asana_id_path, "/tasks/2"}
+
+    assert {:error, :asana_unknown_payload} =
+             AsanaClient.fetch_issues_by_ids_for_test(
+               ["bad"],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 {:ok, %{status: 200, body: %{"data" => Map.put(raw_task("bad"), "name", "")}}}
+               end
+             )
+
+    assert {:ok, []} =
+             AsanaClient.fetch_issues_by_ids_for_test(
+               [],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 flunk("empty Asana IDs should not make an HTTP request")
+               end
+             )
+  end
+
+  test "asana_api preserves REST status and body while rejecting unsafe arguments" do
+    test_pid = self()
+    tracker_settings = tracker_settings()
+
+    response =
+      AsanaAgentTool.execute(
+        "asana_api",
+        %{
+          "method" => "post",
+          "path" => " /tasks/42/stories ",
+          "query" => %{"opt_fields" => "gid"},
+          "body" => %{"data" => %{"text" => "hello"}}
+        },
+        tracker_settings: tracker_settings,
+        asana_client: fn method, path, query, body, opts ->
+          send(test_pid, {:asana_tool_called, method, path, query, body, opts})
+          {:ok, %{status: 201, body: %{"data" => %{"gid" => "story-1"}}}}
+        end
+      )
+
+    assert_received {:asana_tool_called, "POST", "/tasks/42/stories", query, body, opts}
+    assert query == %{"opt_fields" => "gid"}
+    assert body == %{"data" => %{"text" => "hello"}}
+    assert opts == [tracker_settings: tracker_settings]
+
+    assert response["success"] == true
+    assert Jason.decode!(response["output"]) == %{"status" => 201, "body" => %{"data" => %{"gid" => "story-1"}}}
+    assert response["contentItems"] == [%{"type" => "inputText", "text" => response["output"]}]
+
+    failure =
+      AsanaAgentTool.execute(
+        "asana_api",
+        %{"method" => "GET", "path" => "/tasks/404"},
+        asana_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: 404, body: %{"errors" => []}}}
+        end
+      )
+
+    assert failure["success"] == false
+    assert Jason.decode!(failure["output"]) == %{"status" => 404, "body" => %{"errors" => []}}
+
+    Enum.each(
+      [
+        %{"method" => "GET", "path" => "https://app.asana.com/api/1.0/users/me"},
+        %{"method" => "PATCH", "path" => "/users/me"},
+        %{"method" => "GET", "path" => "/users/me", "query" => false},
+        %{"path" => "/users/me"}
+      ],
+      fn arguments ->
+        invalid =
+          AsanaAgentTool.execute(
+            "asana_api",
+            arguments,
+            asana_client: fn _method, _path, _query, _body, _opts ->
+              flunk("invalid asana_api arguments should not call the client")
+            end
+          )
+
+        assert invalid["success"] == false
+      end
+    )
+  end
+
+  test "asana_api reports unsupported tools, malformed calls, and client failures" do
+    unsupported = AsanaAgentTool.execute("not_asana_api", %{}, [])
+    assert unsupported["success"] == false
+    assert Jason.decode!(unsupported["output"])["error"]["supportedTools"] == ["asana_api"]
+
+    Enum.each(
+      ["not-an-object", %{"method" => "GET", "path" => 123}],
+      fn arguments ->
+        invalid =
+          AsanaAgentTool.execute(
+            "asana_api",
+            arguments,
+            asana_client: fn _method, _path, _query, _body, _opts ->
+              flunk("malformed asana_api arguments should not call the client")
+            end
+          )
+
+        assert invalid["success"] == false
+      end
+    )
+
+    malformed_response =
+      AsanaAgentTool.execute(
+        "asana_api",
+        %{"method" => "GET", "path" => "/users/me"},
+        asana_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: "not-an-integer", body: %{}}}
+        end
+      )
+
+    assert malformed_response["success"] == false
+
+    Enum.each(
+      [:missing_asana_api_key, {:asana_api_request, :timeout}, :unexpected_failure],
+      fn reason ->
+        failure =
+          AsanaAgentTool.execute(
+            "asana_api",
+            %{"method" => "GET", "path" => "/users/me"},
+            asana_client: fn _method, _path, _query, _body, _opts ->
+              {:error, reason}
+            end
+          )
+
+        assert failure["success"] == false
+        assert %{"error" => %{"message" => message}} = Jason.decode!(failure["output"])
+        assert is_binary(message)
+      end
+    )
+
+    non_json_body =
+      AsanaAgentTool.execute(
+        "asana_api",
+        %{"method" => "GET", "path" => "/users/me"},
+        asana_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: 200, body: self()}}
+        end
+      )
+
+    assert non_json_body["success"]
+    assert non_json_body["output"] =~ "#PID"
+  end
+
+  test "tracker binds Asana tools and token env names from provider config" do
+    token_env = "SYMPHONY_ASANA_PAT_#{System.unique_integer([:positive])}"
+    previous_token = System.get_env(token_env)
+    System.put_env(token_env, "test-token")
+
+    on_exit(fn -> restore_env(token_env, previous_token) end)
+
+    write_asana_workflow!(Workflow.workflow_file_path(), "$#{token_env}")
+
+    binding = Tracker.bind_agent_tools()
+
+    assert binding.adapter == AsanaAdapter
+    assert binding.secret_environment_names == ["ASANA_PAT", token_env]
+    assert [%{"name" => "asana_api"}] = binding.tool_specs
+    assert :ok = Config.validate!()
+  end
+
+  defp tracker_settings(provider_overrides \\ %{}) do
+    %{
+      kind: "asana",
+      provider:
+        Map.merge(
+          %{
+            "project_gid" => "project-1",
+            "api_key" => "test-token"
+          },
+          provider_overrides
+        ),
+      active_states: ["Todo"],
+      terminal_states: ["Done"]
+    }
+  end
+
+  defp raw_task(gid), do: task_in_section(gid, "Todo", "section-todo")
+
+  defp task_in_section(gid, section_name, section_gid) do
+    %{
+      "gid" => gid,
+      "name" => "Task #{gid}",
+      "notes" => " Notes #{gid} ",
+      "completed" => false,
+      "resource_subtype" => "default_task",
+      "assignee" => %{"gid" => "assignee-1"},
+      "tags" => [%{"name" => " Bug "}, %{"name" => "bug"}, %{"name" => "Platform"}],
+      "memberships" => [
+        %{
+          "project" => %{"gid" => "project-1"},
+          "section" => %{"gid" => section_gid, "name" => section_name}
+        }
+      ],
+      "permalink_url" => "https://app.asana.test/0/project-1/#{gid}",
+      "created_at" => "2026-01-01T00:00:00Z",
+      "modified_at" => "2026-01-02T00:00:00Z"
+    }
+  end
+
+  defp out_of_project_task(gid) do
+    put_in(raw_task(gid), ["memberships", Access.at(0), "project", "gid"], "other-project")
+  end
+
+  defp write_asana_workflow!(path, token) do
+    File.write!(
+      path,
+      """
+      ---
+      tracker:
+        kind: asana
+        provider:
+          project_gid: "project-1"
+          api_key: #{Jason.encode!(token)}
+        active_states: ["Todo"]
+        terminal_states: ["Done"]
+      ---
+
+      You are working on {{ issue.identifier }}.
+      """
+    )
+
+    if Process.whereis(SymphonyElixir.WorkflowStore) do
+      assert :ok = SymphonyElixir.WorkflowStore.force_reload()
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/asana_live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/asana_live_e2e_test.exs
@@ -1,0 +1,486 @@
+defmodule SymphonyElixir.Asana.LiveE2ETest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.Asana.Client, as: AsanaClient
+
+  @moduletag :live_e2e
+  @moduletag timeout: 300_000
+
+  @api_url "https://app.asana.com/api/1.0"
+  @result_file "LIVE_ASANA_E2E_RESULT.txt"
+  @task_fields "gid,name,notes,completed,resource_subtype,memberships.project.gid,memberships.section.gid,memberships.section.name,permalink_url,created_at,modified_at"
+  @live_e2e_skip_reason if(System.get_env("SYMPHONY_RUN_ASANA_LIVE_E2E") != "1",
+                          do: "set SYMPHONY_RUN_ASANA_LIVE_E2E=1 to enable the real Asana/Codex end-to-end test"
+                        )
+
+  @tag skip: @live_e2e_skip_reason
+  test "creates a real Asana project and completes a task through asana_api" do
+    workspace_gid = required_env!("SYMPHONY_LIVE_ASANA_WORKSPACE_GID")
+    token = required_env!("ASANA_PAT")
+    run_id = "symphony-asana-live-e2e-#{System.unique_integer([:positive])}"
+    project_name = "Symphony Asana live e2e #{run_id}"
+    active_name = "Symphony E2E Active #{run_id}"
+    done_name = "Symphony E2E Done #{run_id}"
+    test_root = Path.join(System.tmp_dir!(), run_id)
+    workflow_root = Path.join(test_root, "workflow")
+    workflow_file = Path.join(workflow_root, "WORKFLOW.md")
+    workspace_root = Path.join(test_root, "workspaces")
+    codex_home = isolated_codex_home!(test_root)
+    original_workflow_path = Workflow.workflow_file_path()
+    runtime_pid = Process.whereis(SymphonyElixir.AgentRuntimeSupervisor)
+
+    File.mkdir_p!(workflow_root)
+
+    team_gid = optional_env("SYMPHONY_LIVE_ASANA_TEAM_GID")
+    project = create_project!(workspace_gid, team_gid, token, project_name)
+    project_gid = project["gid"]
+
+    try do
+      active_section = create_section!(project_gid, token, active_name)
+      done_section = create_section!(project_gid, token, done_name)
+      task = create_task!(project_gid, token, "Symphony Asana live e2e task #{run_id}")
+      task_gid = task["gid"]
+
+      try do
+        assert :ok = add_task_to_section(active_section["gid"], task_gid, token)
+
+        task_payload = get_task!(task_gid, token)
+        expected_comment = expected_comment("ASANA-#{task_gid}", run_id)
+
+        assert %Issue{} =
+                 issue =
+                 AsanaClient.normalize_issue_for_test(
+                   task_payload,
+                   tracker_settings(project_gid, active_name, done_name)
+                 )
+
+        stop_agent_runtime_if_running(runtime_pid)
+        Workflow.set_workflow_file_path(workflow_file)
+
+        write_workflow!(
+          workflow_file,
+          project_gid,
+          active_name,
+          done_name,
+          workspace_root,
+          codex_home,
+          live_prompt(project_gid, done_section["gid"], expected_comment)
+        )
+
+        assert %Issue{id: state_issue_id} = wait_for_active_state_issue!(issue.id, active_name)
+        assert state_issue_id == issue.id
+
+        assert {:ok, [%Issue{id: issue_id, identifier: identifier}]} =
+                 Tracker.fetch_issues_by_ids([issue.id])
+
+        assert issue_id == issue.id
+        assert identifier == issue.identifier
+
+        assert :ok = AgentRunner.run(issue, self(), max_turns: 3)
+
+        runtime_info = receive_runtime_info!(issue.id)
+        tool_calls = completed_asana_tool_calls(issue.id)
+
+        assert File.read!(Path.join(runtime_info.workspace_path, @result_file)) ==
+                 expected_result(issue.identifier, project_gid)
+
+        final_task = get_task!(task_gid, token)
+        assert final_task["completed"] == true
+        assert task_in_section?(final_task, project_gid, done_section["gid"])
+
+        assert stories!(task_gid, token)
+               |> Enum.any?(&(&1["resource_subtype"] == "comment_added" and &1["text"] == expected_comment))
+
+        task_path = "/tasks/#{task_gid}"
+        stories_path = task_path <> "/stories"
+        move_path = "/sections/#{done_section["gid"]}/addTask"
+
+        assert_tool_call_count!(tool_calls, "GET", task_path, 2)
+        assert_tool_call_count!(tool_calls, "GET", stories_path, 2)
+        assert_tool_call!(tool_calls, "POST", stories_path, %{"data" => %{"text" => expected_comment}})
+        assert_tool_call!(tool_calls, "POST", move_path, %{"data" => %{"task" => task_gid}})
+        assert_tool_call!(tool_calls, "PUT", task_path, %{"data" => %{"completed" => true}})
+      after
+        task_cleanup_result = delete_task(task_gid, token)
+        task_readback = get_resource("/tasks/#{task_gid}", token)
+        assert :ok = task_cleanup_result
+        assert :not_found = task_readback
+      end
+    after
+      cleanup_result = delete_project(project_gid, token)
+      project_readback = get_resource("/projects/#{project_gid}", token)
+      Workflow.set_workflow_file_path(original_workflow_path)
+      restart_agent_runtime_if_needed(runtime_pid)
+      File.rm_rf(test_root)
+      assert :ok = cleanup_result
+      assert :not_found = project_readback
+    end
+  end
+
+  defp tracker_settings(project_gid, active_name, done_name) do
+    %{
+      kind: "asana",
+      provider: %{"project_gid" => project_gid, "api_key" => "test-token"},
+      active_states: [active_name],
+      terminal_states: [done_name]
+    }
+  end
+
+  defp write_workflow!(path, project_gid, active_name, done_name, workspace_root, codex_home, prompt) do
+    File.write!(
+      path,
+      """
+      ---
+      tracker:
+        kind: asana
+        provider:
+          project_gid: #{Jason.encode!(project_gid)}
+          api_key: "$ASANA_PAT"
+        active_states: [#{Jason.encode!(active_name)}]
+        terminal_states: [#{Jason.encode!(done_name)}]
+      workspace:
+        root: #{Jason.encode!(workspace_root)}
+      agent:
+        max_turns: 3
+      codex:
+        command: #{Jason.encode!("env CODEX_HOME=#{shell_escape(codex_home)} codex app-server")}
+        approval_policy: "never"
+        read_timeout_ms: 60000
+        turn_timeout_ms: 600000
+        stall_timeout_ms: 600000
+      observability:
+        dashboard_enabled: false
+      ---
+
+      #{prompt}
+      """
+    )
+
+    assert :ok = SymphonyElixir.WorkflowStore.force_reload()
+  end
+
+  defp live_prompt(project_gid, done_section_gid, expected_comment) do
+    task_path = "/tasks/{{ issue.id }}"
+    stories_path = task_path <> "/stories"
+
+    """
+    You are running a real Symphony Asana end-to-end test.
+
+    The current working directory is the workspace root.
+
+    Step 1:
+    Run exactly:
+
+    ```sh
+    if [ -n "${ASANA_PAT:-}" ]; then asana_pat_present=yes; else asana_pat_present=no; fi
+    cat > #{@result_file} <<EOF
+    identifier={{ issue.identifier }}
+    project_gid=#{project_gid}
+    asana_pat_present=$asana_pat_present
+    EOF
+    ```
+
+    Then verify the file with `cat #{@result_file}`. The final line must be `asana_pat_present=no`.
+
+    Step 2:
+    You must use `asana_api` for every Asana operation. First GET both:
+    - #{task_path}
+    - #{stories_path}
+
+    If the exact comment below is not already present, POST it once to #{stories_path} using `body: {"data": {"text": "..."}}` with the exact text below:
+    #{expected_comment}
+
+    Step 3:
+    POST /sections/#{done_section_gid}/addTask using `body: {"data": {"task": "{{ issue.id }}"}}`.
+    Then PUT #{task_path} using `body: {"data": {"completed": true}}`.
+
+    Step 4:
+    Use `asana_api` again to GET #{task_path} and #{stories_path}. Stop only after:
+    1. #{@result_file} has the exact three lines above and says `asana_pat_present=no`
+    2. the exact comment is present
+    3. the task is completed and belongs to section #{done_section_gid}
+
+    Do not ask for approval.
+    """
+  end
+
+  defp expected_result(identifier, project_gid) do
+    "identifier=#{identifier}\nproject_gid=#{project_gid}\nasana_pat_present=no\n"
+  end
+
+  defp expected_comment(identifier, run_id) do
+    "Symphony Asana live e2e comment\nidentifier=#{identifier}\nrun_id=#{run_id}"
+  end
+
+  defp create_project!(workspace_gid, team_gid, token, name) do
+    data = %{"name" => name, "workspace" => workspace_gid} |> maybe_put("team", team_gid)
+
+    asana_data!(
+      :post,
+      "/projects",
+      token,
+      %{"data" => data}
+    )
+  end
+
+  defp create_section!(project_gid, token, name) do
+    asana_data!(
+      :post,
+      "/projects/#{project_gid}/sections",
+      token,
+      %{"data" => %{"name" => name}}
+    )
+  end
+
+  defp create_task!(project_gid, token, name) do
+    asana_data!(
+      :post,
+      "/tasks",
+      token,
+      %{"data" => %{"name" => name, "projects" => [project_gid]}}
+    )
+  end
+
+  defp get_task!(task_gid, token) do
+    asana_data!(:get, "/tasks/#{task_gid}", token, nil, %{"opt_fields" => @task_fields})
+  end
+
+  defp stories!(task_gid, token) do
+    case asana_request!(
+           :get,
+           "/tasks/#{task_gid}/stories",
+           token,
+           nil,
+           %{"opt_fields" => "resource_subtype,text", "limit" => 100}
+         ).body do
+      %{"data" => stories} when is_list(stories) -> stories
+      _ -> flunk("Asana stories read returned an unexpected payload")
+    end
+  end
+
+  defp add_task_to_section(section_gid, task_gid, token) do
+    case asana_request(
+           :post,
+           "/sections/#{section_gid}/addTask",
+           token,
+           %{"data" => %{"task" => task_gid}}
+         ) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: status}} -> {:error, {:asana_add_task_status, status}}
+      {:error, reason} -> {:error, {:asana_add_task_request, reason}}
+    end
+  end
+
+  defp delete_project(project_gid, token) do
+    case asana_request(:delete, "/projects/#{project_gid}", token, nil) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: 404}} -> :ok
+      {:ok, %{status: status}} -> {:error, {:asana_cleanup_status, status}}
+      {:error, reason} -> {:error, {:asana_cleanup_request, reason}}
+    end
+  end
+
+  defp delete_task(task_gid, token) do
+    case asana_request(:delete, "/tasks/#{task_gid}", token, nil) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: 404}} -> :ok
+      {:ok, %{status: status}} -> {:error, {:asana_task_cleanup_status, status}}
+      {:error, reason} -> {:error, {:asana_task_cleanup_request, reason}}
+    end
+  end
+
+  defp get_resource(path, token) do
+    case asana_request(:get, path, token, nil) do
+      {:ok, %{status: 404}} -> :not_found
+      {:ok, %{status: status}} when status in 200..299 -> :found
+      {:ok, %{status: status}} -> flunk("Asana cleanup read failed with HTTP #{status}")
+      {:error, reason} -> flunk("Asana cleanup read failed before a response: #{inspect(reason)}")
+    end
+  end
+
+  defp asana_data!(method, path, token, body, query \\ %{}) do
+    case asana_request!(method, path, token, body, query).body do
+      %{"data" => %{} = data} -> data
+      _ -> flunk("Asana request returned an unexpected data payload")
+    end
+  end
+
+  defp asana_request!(method, path, token, body, query) do
+    case asana_request(method, path, token, body, query) do
+      {:ok, %{status: status} = response} when status in 200..299 -> response
+      {:ok, %{status: status}} -> flunk("Asana request failed with HTTP #{status}")
+      {:error, reason} -> flunk("Asana request failed before a response: #{inspect(reason)}")
+    end
+  end
+
+  defp asana_request(method, path, token, body, query \\ %{}) do
+    request_opts = [
+      method: method,
+      url: @api_url <> path,
+      headers: [
+        {"Accept", "application/json"},
+        {"Authorization", "Bearer #{token}"}
+      ],
+      params: query,
+      connect_options: [timeout: 30_000]
+    ]
+
+    request_opts = if is_nil(body), do: request_opts, else: Keyword.put(request_opts, :json, body)
+
+    case Req.request(request_opts) do
+      {:ok, response} -> {:ok, %{status: response.status, body: response.body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp task_in_section?(%{"memberships" => memberships}, project_gid, section_gid)
+       when is_list(memberships) do
+    Enum.any?(memberships, fn membership ->
+      get_in(membership, ["project", "gid"]) == project_gid and
+        get_in(membership, ["section", "gid"]) == section_gid
+    end)
+  end
+
+  defp task_in_section?(_task, _project_gid, _section_gid), do: false
+
+  defp receive_runtime_info!(issue_id) do
+    receive do
+      {:worker_runtime_info, ^issue_id, %{workspace_path: workspace_path} = runtime_info}
+      when is_binary(workspace_path) ->
+        runtime_info
+
+      {:codex_worker_update, ^issue_id, _message} ->
+        receive_runtime_info!(issue_id)
+    after
+      5_000 ->
+        flunk("timed out waiting for worker runtime info")
+    end
+  end
+
+  defp completed_asana_tool_calls(issue_id, calls \\ []) do
+    receive do
+      {:codex_worker_update, ^issue_id, %{event: :tool_call_completed, payload: %{"params" => params}}} ->
+        completed_asana_tool_calls(issue_id, [params | calls])
+
+      {:codex_worker_update, ^issue_id, _message} ->
+        completed_asana_tool_calls(issue_id, calls)
+    after
+      0 ->
+        Enum.reverse(calls)
+    end
+  end
+
+  defp assert_tool_call!(calls, method, path, expected_body) do
+    found? =
+      Enum.any?(calls, fn params ->
+        tool_call_matches?(params, method, path) and
+          get_in(params, ["arguments", "body"]) == expected_body
+      end)
+
+    assert found?, "expected completed asana_api #{method} #{path}"
+  end
+
+  defp assert_tool_call_count!(calls, method, path, expected_count) do
+    count = Enum.count(calls, &tool_call_matches?(&1, method, path))
+    assert count >= expected_count, "expected at least #{expected_count} completed asana_api #{method} #{path} calls"
+  end
+
+  defp tool_call_matches?(params, method, path) do
+    arguments = Map.get(params, "arguments", %{})
+    tool_name = Map.get(params, "name") || Map.get(params, "tool")
+    called_method = Map.get(arguments, "method")
+    called_path = Map.get(arguments, "path")
+
+    tool_name == "asana_api" and is_binary(called_method) and
+      String.upcase(String.trim(called_method)) == method and
+      is_binary(called_path) and String.trim(called_path) == path
+  end
+
+  defp wait_for_active_state_issue!(issue_id, state, attempts \\ 20)
+
+  defp wait_for_active_state_issue!(issue_id, state, attempts) when attempts > 0 do
+    case Tracker.fetch_issues_by_states([state]) do
+      {:ok, issues} ->
+        case Enum.find(issues, &(&1.id == issue_id)) do
+          %Issue{} = issue ->
+            issue
+
+          nil ->
+            Process.sleep(500)
+            wait_for_active_state_issue!(issue_id, state, attempts - 1)
+        end
+
+      {:error, reason} ->
+        flunk("Asana state read failed: #{inspect(reason)}")
+    end
+  end
+
+  defp wait_for_active_state_issue!(_issue_id, _state, 0) do
+    flunk("new Asana task did not appear in the active-state adapter read")
+  end
+
+  defp isolated_codex_home!(test_root) do
+    codex_home = Path.join(test_root, "codex-home")
+    auth_json_path = Path.join(codex_home, "auth.json")
+
+    source_auth_json =
+      Path.join(
+        System.get_env("CODEX_HOME") || Path.join(System.user_home!(), ".codex"),
+        "auth.json"
+      )
+
+    unless File.regular?(source_auth_json) do
+      flunk("live Asana e2e requires Codex auth")
+    end
+
+    File.mkdir_p!(codex_home)
+    File.cp!(source_auth_json, auth_json_path)
+    File.chmod!(auth_json_path, 0o600)
+    codex_home
+  end
+
+  defp stop_agent_runtime_if_running(runtime_pid) when is_pid(runtime_pid) do
+    assert :ok =
+             Supervisor.terminate_child(
+               SymphonyElixir.Supervisor,
+               SymphonyElixir.AgentRuntimeSupervisor
+             )
+  end
+
+  defp stop_agent_runtime_if_running(_runtime_pid), do: :ok
+
+  defp restart_agent_runtime_if_needed(runtime_pid) when is_pid(runtime_pid) do
+    if is_nil(Process.whereis(SymphonyElixir.AgentRuntimeSupervisor)) do
+      case Supervisor.restart_child(
+             SymphonyElixir.Supervisor,
+             SymphonyElixir.AgentRuntimeSupervisor
+           ) do
+        {:ok, _pid} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+  end
+
+  defp restart_agent_runtime_if_needed(_runtime_pid), do: :ok
+
+  defp required_env!(name) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> value
+      _ -> flunk("live Asana e2e requires #{name}")
+    end
+  end
+
+  defp optional_env(name) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp shell_escape(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+end


### PR DESCRIPTION
#### Context

Symphony's generic tracker seam needs an Asana implementation without adding generic mutation APIs.

#### TL;DR

*Add Asana task reads and a host-authenticated raw Asana API tool.*

#### Summary

- Add project-scoped Asana task reads, section-state mapping, and dispatchability.
- Add raw `asana_api` for provider-native mutations with host-side auth.
- Add contract tests, live E2E proof, and Asana adapter documentation.

#### Alternatives

- Generic CRUD was rejected because it would flatten sections, stories, and task types.
- Completed-only state mapping was rejected because section names are the workflow source.

#### Test Plan

- [x] `make -C elixir all`
- [x] `SYMPHONY_RUN_ASANA_LIVE_E2E=1 mix test test/symphony_elixir/asana_live_e2e_test.exs`
- [x] `SYMPHONY_RUN_LIVE_E2E=1 SYMPHONY_LIVE_LINEAR_TEAM_KEY=FST mix test test/symphony_elixir/live_e2e_test.exs:123`
