### PR TITLE
Add GitLab Issues tracker adapter

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -169,8 +169,6 @@ Notes:
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
 - For the Linear adapter, `tracker.provider.api_key` reads from `LINEAR_API_KEY` when unset or
   when value is `$LINEAR_API_KEY`. The legacy flat `tracker.api_key` alias behaves the same way.
-- For the GitLab adapter, `tracker.provider.api_key` reads from `GITLAB_PAT` when unset; `$VAR`
-  references are also supported.
 - Do not put a literal tracker token in a repo-owned `WORKFLOW.md` if Codex can read that
   workspace. Use `$VAR`/host-side secret references so Symphony can keep the token out of the
   child environment.
@@ -240,39 +238,13 @@ codex:
   `tracker_payload`, and missing cursors to `tracker_pagination`; logs and tool responses carry the
   human-readable provider detail.
 
-### GitLab adapter profile
+### GitLab adapter
 
-- Config: use `tracker.kind: gitlab` with required `tracker.provider.project_path`, optional
-  `api_url` (default `https://gitlab.com/api/v4`), and `api_key` (defaults to `GITLAB_PAT` and
-  accepts `$VAR`). `project_path` may be a namespaced path such as
-  `group/project` or a quoted numeric project ID. Keep explicit `active_states: ["opened"]` and
-  `terminal_states: ["closed"]` under `tracker`.
-- Scope and paging: candidate reads list issues in the configured project with GitLab offset
-  pagination and locally filter requested `opened`/`closed` states. ID refreshes use project-local
-  issue IIDs, preserve requested order, omit 404s, and fail malformed requested records. Empty
-  state/ID lists return `{:ok, []}` without a GitLab request.
-- Identity and normalization: `issue.id` is the project-local IID string, `issue.identifier` is
-  route-safe `GL-<iid>`, and `issue.native_ref` retains GitLab's global ID, IID, project ID/path,
-  and references map. Description, state, web URL, stable assignee ID, labels, and RFC 3339
-  timestamps map onto the generic issue. Labels are trimmed, lowercased, deduplicated, and blanks
-  are dropped; priority, branch name, and blockers stay unset because GitLab does not expose a
-  matching generic meaning in the issue list.
-- Dispatchability: every valid scoped GitLab issue remains provider-dispatchable, including
-  confidential and nonstandard issue types visible to the configured token. The generic scheduler
-  applies active/terminal states, required labels, claims, retries, and concurrency.
-- Tool: the adapter advertises `gitlab_api`, accepting `method`, a relative GitLab REST `path`, an
-  optional object `query`, and optional JSON `body`. Symphony forwards the body unchanged,
-  executes the request host-side with the session-bound endpoint/token using `PRIVATE-TOKEN`,
-  preserves REST status/body in the tool result, and strips `GITLAB_PAT`, `GITLAB_ACCESS_TOKEN`,
-  plus any configured `$VAR` token name from the Codex child. Project scope applies to scheduler
-  reads, not raw tool calls.
-- Responsibility and errors: `gitlab_api` adds no idempotency, retry, or scope policy; workflows
-  own provider-specific mutations and error handling. Read/config failures use
-  `{:error, :missing_gitlab_api_key}`, `{:error, :missing_gitlab_project_path}`,
-  `{:error, :invalid_gitlab_project_path}`, `{:error, :invalid_gitlab_api_url}`,
-  `{:error, :invalid_gitlab_issue_id}`, `{:error, {:gitlab_api_status, status}}`,
-  `{:error, {:gitlab_api_request, reason}}`, or `{:error, :gitlab_unknown_payload}`. Tool results
-  use the same `success`/JSON `output`/text `contentItems` shape as other provider-native tools.
+- Configure `tracker.kind: gitlab` with `tracker.provider.project_path`, optional `api_url`, and
+  `api_key` (default `GITLAB_PAT`); use `opened` and `closed` tracker states.
+- Symphony reads project issues by IID and exposes route-safe `GL-<iid>` identifiers.
+- `gitlab_api` forwards raw GitLab REST requests with host-side auth and keeps GitLab token env vars
+  out of the Codex child.
 
 ## Web dashboard
 
@@ -327,8 +299,7 @@ The live test creates a temporary Linear project and issue, writes a temporary `
 a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
 Linear issue, then marks the project completed so the run remains visible in Linear.
 
-Run the opt-in GitLab live E2E separately when you want Symphony to create and delete a disposable
-issue while exercising a real `codex app-server` session:
+Run the opt-in GitLab live E2E against a disposable project:
 
 ```bash
 cd elixir
@@ -336,10 +307,6 @@ export GITLAB_PAT=...
 export SYMPHONY_LIVE_GITLAB_PROJECT_ID=...
 SYMPHONY_RUN_GITLAB_LIVE_E2E=1 mix test test/symphony_elixir/gitlab_live_e2e_test.exs
 ```
-
-The GitLab live test verifies both tracker reads, a workspace file proving the child did not
-inherit GitLab token variables, real `gitlab_api` note and close calls, direct API readback, and
-issue deletion.
 
 ## FAQ
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -13,7 +13,7 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 ## How it works
 
-1. Polls the configured tracker for candidate work (the included production adapter is Linear)
+1. Polls the configured tracker for candidate work (included production adapters are Linear and GitLab)
 2. Creates a workspace per issue
 3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
    workspace
@@ -21,9 +21,9 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 5. Keeps Codex working on the issue until the work is done
 
 During app-server sessions, the selected tracker adapter may advertise provider-native tools. The
-included Linear adapter serves `linear_graphql` so repo skills can make raw Linear GraphQL calls.
-Symphony executes that tool with its configured auth and removes `LINEAR_API_KEY` from the Codex
-child environment, so the agent does not need a second tracker login.
+Linear adapter serves `linear_graphql`; the GitLab adapter serves `gitlab_api`. Symphony executes
+those tools with configured auth and removes each adapter's declared token environment variables
+from the Codex child, so the agent does not need a second tracker login.
 
 If a claimed issue moves to a terminal state (`Done`, `Closed`, `Cancelled`, or `Duplicate`),
 Symphony stops the active agent for that issue and cleans up matching workspaces.
@@ -169,6 +169,8 @@ Notes:
   the project dependencies in `hooks.after_create` before invoking `mise` later from other hooks.
 - For the Linear adapter, `tracker.provider.api_key` reads from `LINEAR_API_KEY` when unset or
   when value is `$LINEAR_API_KEY`. The legacy flat `tracker.api_key` alias behaves the same way.
+- For the GitLab adapter, `tracker.provider.api_key` reads from `GITLAB_PAT` when unset; `$VAR`
+  references are also supported.
 - Do not put a literal tracker token in a repo-owned `WORKFLOW.md` if Codex can read that
   workspace. Use `$VAR`/host-side secret references so Symphony can keep the token out of the
   child environment.
@@ -238,6 +240,40 @@ codex:
   `tracker_payload`, and missing cursors to `tracker_pagination`; logs and tool responses carry the
   human-readable provider detail.
 
+### GitLab adapter profile
+
+- Config: use `tracker.kind: gitlab` with required `tracker.provider.project_path`, optional
+  `api_url` (default `https://gitlab.com/api/v4`), and `api_key` (defaults to `GITLAB_PAT` and
+  accepts `$VAR`). `project_path` may be a namespaced path such as
+  `group/project` or a quoted numeric project ID. Keep explicit `active_states: ["opened"]` and
+  `terminal_states: ["closed"]` under `tracker`.
+- Scope and paging: candidate reads list issues in the configured project with GitLab offset
+  pagination and locally filter requested `opened`/`closed` states. ID refreshes use project-local
+  issue IIDs, preserve requested order, omit 404s, and fail malformed requested records. Empty
+  state/ID lists return `{:ok, []}` without a GitLab request.
+- Identity and normalization: `issue.id` is the project-local IID string, `issue.identifier` is
+  route-safe `GL-<iid>`, and `issue.native_ref` retains GitLab's global ID, IID, project ID/path,
+  and references map. Description, state, web URL, stable assignee ID, labels, and RFC 3339
+  timestamps map onto the generic issue. Labels are trimmed, lowercased, deduplicated, and blanks
+  are dropped; priority, branch name, and blockers stay unset because GitLab does not expose a
+  matching generic meaning in the issue list.
+- Dispatchability: every valid scoped GitLab issue remains provider-dispatchable, including
+  confidential and nonstandard issue types visible to the configured token. The generic scheduler
+  applies active/terminal states, required labels, claims, retries, and concurrency.
+- Tool: the adapter advertises `gitlab_api`, accepting `method`, a relative GitLab REST `path`, an
+  optional object `query`, and optional JSON `body`. Symphony forwards the body unchanged,
+  executes the request host-side with the session-bound endpoint/token using `PRIVATE-TOKEN`,
+  preserves REST status/body in the tool result, and strips `GITLAB_PAT`, `GITLAB_ACCESS_TOKEN`,
+  plus any configured `$VAR` token name from the Codex child. Project scope applies to scheduler
+  reads, not raw tool calls.
+- Responsibility and errors: `gitlab_api` adds no idempotency, retry, or scope policy; workflows
+  own provider-specific mutations and error handling. Read/config failures use
+  `{:error, :missing_gitlab_api_key}`, `{:error, :missing_gitlab_project_path}`,
+  `{:error, :invalid_gitlab_project_path}`, `{:error, :invalid_gitlab_api_url}`,
+  `{:error, :invalid_gitlab_issue_id}`, `{:error, {:gitlab_api_status, status}}`,
+  `{:error, {:gitlab_api_request, reason}}`, or `{:error, :gitlab_unknown_payload}`. Tool results
+  use the same `success`/JSON `output`/text `contentItems` shape as other provider-native tools.
+
 ## Web dashboard
 
 The observability UI now runs on a minimal Phoenix stack:
@@ -290,6 +326,20 @@ Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `make e2e` to target real SSH h
 The live test creates a temporary Linear project and issue, writes a temporary `WORKFLOW.md`, runs
 a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
 Linear issue, then marks the project completed so the run remains visible in Linear.
+
+Run the opt-in GitLab live E2E separately when you want Symphony to create and delete a disposable
+issue while exercising a real `codex app-server` session:
+
+```bash
+cd elixir
+export GITLAB_PAT=...
+export SYMPHONY_LIVE_GITLAB_PROJECT_ID=...
+SYMPHONY_RUN_GITLAB_LIVE_E2E=1 mix test test/symphony_elixir/gitlab_live_e2e_test.exs
+```
+
+The GitLab live test verifies both tracker reads, a workspace file proving the child did not
+inherit GitLab token variables, real `gitlab_api` note and close calls, direct API readback, and
+issue deletion.
 
 ## FAQ
 

--- a/elixir/lib/symphony_elixir/gitlab/adapter.ex
+++ b/elixir/lib/symphony_elixir/gitlab/adapter.ex
@@ -1,0 +1,63 @@
+defmodule SymphonyElixir.GitLab.Adapter do
+  @moduledoc """
+  GitLab Issues-backed tracker adapter.
+  """
+
+  @behaviour SymphonyElixir.Tracker
+
+  alias SymphonyElixir.GitLab.{AgentTool, Client}
+  alias SymphonyElixir.Tracker.Issue
+
+  @active_states ["opened"]
+  @terminal_states ["closed"]
+
+  @spec validate_config(map()) :: :ok | {:error, term()}
+  def validate_config(tracker_settings) do
+    with :ok <-
+           validate_states(
+             tracker_settings.active_states,
+             @active_states,
+             :missing_gitlab_active_states
+           ),
+         :ok <-
+           validate_states(
+             tracker_settings.terminal_states,
+             @terminal_states,
+             :missing_gitlab_terminal_states
+           ) do
+      Client.validate_settings(tracker_settings)
+    end
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(states), do: client_module().fetch_issues_by_states(states)
+
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(ids), do: client_module().fetch_issues_by_ids(ids)
+
+  @spec agent_tool_specs() :: [map()]
+  def agent_tool_specs, do: AgentTool.tool_specs()
+
+  @spec execute_agent_tool(String.t(), term(), keyword()) :: map()
+  def execute_agent_tool(tool, arguments, opts), do: AgentTool.execute(tool, arguments, opts)
+
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(tracker_settings), do: Client.secret_environment_names(tracker_settings)
+
+  defp client_module do
+    Application.get_env(:symphony_elixir, :gitlab_client_module, Client)
+  end
+
+  defp validate_states(states, allowed_states, _missing_error) when is_list(states) do
+    if Enum.all?(states, &(normalize_state(&1) in allowed_states)) do
+      :ok
+    else
+      {:error, :invalid_gitlab_states}
+    end
+  end
+
+  defp validate_states(_states, _allowed_states, missing_error), do: {:error, missing_error}
+
+  defp normalize_state(state) when is_binary(state), do: state |> String.trim() |> String.downcase()
+  defp normalize_state(_state), do: ""
+end

--- a/elixir/lib/symphony_elixir/gitlab/agent_tool.ex
+++ b/elixir/lib/symphony_elixir/gitlab/agent_tool.ex
@@ -1,0 +1,174 @@
+defmodule SymphonyElixir.GitLab.AgentTool do
+  @moduledoc """
+  Provider-native GitLab REST tool exposed to Codex app-server turns.
+  """
+
+  alias SymphonyElixir.GitLab.Client
+
+  @gitlab_api_tool "gitlab_api"
+  @allowed_methods ["GET", "POST", "PUT", "DELETE"]
+  @gitlab_api_description """
+  Execute a GitLab REST API request using Symphony's configured auth.
+  """
+  @gitlab_api_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["method", "path"],
+    "properties" => %{
+      "method" => %{
+        "type" => "string",
+        "enum" => @allowed_methods,
+        "description" => "GitLab REST method."
+      },
+      "path" => %{
+        "type" => "string",
+        "description" => "GitLab REST path such as /projects/group%2Frepo/issues/1/notes."
+      },
+      "query" => %{
+        "type" => ["object", "null"],
+        "description" => "Optional query parameters.",
+        "additionalProperties" => true
+      },
+      "body" => %{
+        "description" => "Optional JSON request body."
+      }
+    }
+  }
+
+  @spec execute(String.t() | nil, term(), keyword()) :: map()
+  def execute(tool, arguments, opts) do
+    case tool do
+      @gitlab_api_tool -> execute_gitlab_api(arguments, opts)
+      other -> unsupported_tool_response(other)
+    end
+  end
+
+  @spec tool_specs() :: [map()]
+  def tool_specs do
+    [
+      %{
+        "name" => @gitlab_api_tool,
+        "description" => @gitlab_api_description,
+        "inputSchema" => @gitlab_api_input_schema
+      }
+    ]
+  end
+
+  defp execute_gitlab_api(arguments, opts) do
+    gitlab_client = Keyword.get(opts, :gitlab_client, &Client.request/5)
+    client_opts = Keyword.take(opts, [:tracker_settings])
+
+    with {:ok, method, path, query, body} <- normalize_arguments(arguments),
+         {:ok, %{status: status, body: response_body}} <-
+           gitlab_client.(method, path, query, body, client_opts),
+         true <- is_integer(status) do
+      rest_response(status, response_body)
+    else
+      {:error, reason} -> failure_response(tool_error_payload(reason))
+      _ -> failure_response(tool_error_payload(:gitlab_unknown_payload))
+    end
+  end
+
+  defp normalize_arguments(arguments) when is_map(arguments) do
+    with {:ok, method} <- normalize_method(Map.get(arguments, "method")),
+         {:ok, path} <- normalize_path(Map.get(arguments, "path")),
+         {:ok, query} <- normalize_query(Map.get(arguments, "query")) do
+      {:ok, method, path, query, Map.get(arguments, "body")}
+    end
+  end
+
+  defp normalize_arguments(_arguments), do: {:error, :invalid_arguments}
+
+  defp normalize_method(method) when is_binary(method) do
+    normalized = method |> String.trim() |> String.upcase()
+    if normalized in @allowed_methods, do: {:ok, normalized}, else: {:error, :invalid_method}
+  end
+
+  defp normalize_method(_method), do: {:error, :invalid_method}
+
+  defp normalize_path(path) when is_binary(path) do
+    trimmed = String.trim(path)
+
+    if String.starts_with?(trimmed, "/") and
+         not String.contains?(trimmed, ["://", "\n", "\r", <<0>>]) do
+      {:ok, trimmed}
+    else
+      {:error, :invalid_path}
+    end
+  end
+
+  defp normalize_path(_path), do: {:error, :invalid_path}
+
+  defp normalize_query(nil), do: {:ok, %{}}
+  defp normalize_query(query) when is_map(query), do: {:ok, query}
+  defp normalize_query(_query), do: {:error, :invalid_query}
+
+  defp rest_response(status, body) do
+    dynamic_tool_response(status in 200..299, encode_payload(%{"status" => status, "body" => body}))
+  end
+
+  defp failure_response(payload), do: dynamic_tool_response(false, encode_payload(payload))
+
+  defp dynamic_tool_response(success, output) do
+    %{
+      "success" => success,
+      "output" => output,
+      "contentItems" => [%{"type" => "inputText", "text" => output}]
+    }
+  end
+
+  defp encode_payload(payload) do
+    case Jason.encode(payload, pretty: true) do
+      {:ok, output} -> output
+      {:error, _reason} -> inspect(payload)
+    end
+  end
+
+  defp unsupported_tool_response(tool) do
+    failure_response(%{
+      "error" => %{
+        "message" => "Unsupported dynamic tool: #{inspect(tool)}.",
+        "supportedTools" => supported_tool_names()
+      }
+    })
+  end
+
+  defp tool_error_payload(:invalid_arguments) do
+    %{"error" => %{"message" => "gitlab_api expects an object with method and path."}}
+  end
+
+  defp tool_error_payload(:invalid_method) do
+    %{"error" => %{"message" => "gitlab_api.method must be GET, POST, PUT, or DELETE."}}
+  end
+
+  defp tool_error_payload(:invalid_path) do
+    %{"error" => %{"message" => "gitlab_api.path must be a relative GitLab REST path."}}
+  end
+
+  defp tool_error_payload(:invalid_query) do
+    %{"error" => %{"message" => "gitlab_api.query must be a JSON object when provided."}}
+  end
+
+  defp tool_error_payload(:missing_gitlab_api_key) do
+    %{
+      "error" => %{
+        "message" => "Symphony is missing GitLab auth. Set tracker.provider.api_key or export GITLAB_PAT."
+      }
+    }
+  end
+
+  defp tool_error_payload({:gitlab_api_request, reason}) do
+    %{
+      "error" => %{
+        "message" => "GitLab API request failed before receiving a successful response.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp tool_error_payload(reason) do
+    %{"error" => %{"message" => "GitLab REST tool execution failed.", "reason" => inspect(reason)}}
+  end
+
+  defp supported_tool_names, do: Enum.map(tool_specs(), & &1["name"])
+end

--- a/elixir/lib/symphony_elixir/gitlab/client.ex
+++ b/elixir/lib/symphony_elixir/gitlab/client.ex
@@ -1,0 +1,414 @@
+defmodule SymphonyElixir.GitLab.Client do
+  @moduledoc """
+  Thin GitLab REST client for project-scoped issue polling.
+  """
+
+  require Logger
+  alias SymphonyElixir.Config
+  alias SymphonyElixir.Tracker.Issue
+
+  @default_api_url "https://gitlab.com/api/v4"
+  @page_size 100
+
+  @spec validate_settings(map()) :: :ok | {:error, term()}
+  def validate_settings(tracker_settings) do
+    with {:ok, _settings} <- settings(tracker_settings), do: :ok
+  end
+
+  @spec secret_environment_names(map()) :: [String.t()]
+  def secret_environment_names(tracker_settings) do
+    provider = provider_settings(tracker_settings)
+
+    ["GITLAB_PAT", "GITLAB_ACCESS_TOKEN" | env_reference_names([provider["api_key"]])]
+    |> Enum.uniq()
+  end
+
+  @spec fetch_issues_by_states([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states(states) when is_list(states) do
+    fetch_issues_by_states(states, Config.settings!().tracker, &perform_request/5)
+  end
+
+  @spec fetch_issues_by_ids([String.t()]) :: {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids(ids) when is_list(ids) do
+    fetch_issues_by_ids(ids, Config.settings!().tracker, &perform_request/5)
+  end
+
+  @spec request(String.t(), String.t(), map(), term(), keyword()) ::
+          {:ok, %{status: integer(), body: term()}} | {:error, term()}
+  def request(method, path, query, body, opts \\ [])
+      when is_binary(method) and is_binary(path) and is_map(query) and is_list(opts) do
+    tracker_settings = Keyword.get_lazy(opts, :tracker_settings, fn -> Config.settings!().tracker end)
+    request_fun = Keyword.get(opts, :request_fun, &perform_request/5)
+
+    with {:ok, gitlab_settings} <- settings(tracker_settings) do
+      request_fun.(method, path, query, body, gitlab_settings)
+    end
+  end
+
+  @doc false
+  @spec normalize_issue_for_test(map(), map()) :: Issue.t() | nil
+  def normalize_issue_for_test(issue, tracker_settings)
+      when is_map(issue) and is_map(tracker_settings) do
+    case settings(tracker_settings) do
+      {:ok, gitlab_settings} -> normalize_issue(issue, gitlab_settings)
+      _ -> nil
+    end
+  end
+
+  @doc false
+  @spec fetch_issues_by_states_for_test([String.t()], map(), function()) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_states_for_test(states, tracker_settings, request_fun)
+      when is_list(states) and is_map(tracker_settings) and is_function(request_fun, 5) do
+    fetch_issues_by_states(states, tracker_settings, request_fun)
+  end
+
+  @doc false
+  @spec fetch_issues_by_ids_for_test([String.t()], map(), function()) ::
+          {:ok, [Issue.t()]} | {:error, term()}
+  def fetch_issues_by_ids_for_test(ids, tracker_settings, request_fun)
+      when is_list(ids) and is_map(tracker_settings) and is_function(request_fun, 5) do
+    fetch_issues_by_ids(ids, tracker_settings, request_fun)
+  end
+
+  defp fetch_issues_by_states(states, tracker_settings, request_fun) do
+    normalized_states = states |> Enum.map(&normalize_state/1) |> MapSet.new()
+
+    case gitlab_state_query(normalized_states) do
+      nil ->
+        {:ok, []}
+
+      state_query ->
+        with {:ok, gitlab_settings} <- settings(tracker_settings) do
+          fetch_issue_pages(gitlab_settings, state_query, normalized_states, 1, request_fun, [])
+        end
+    end
+  end
+
+  defp fetch_issue_pages(settings, state_query, requested_states, page, request_fun, pages) do
+    query = %{
+      "state" => state_query,
+      "per_page" => @page_size,
+      "page" => page,
+      "order_by" => "created_at",
+      "sort" => "asc"
+    }
+
+    with {:ok, payload} <-
+           request_with_settings(
+             "GET",
+             project_issues_path(settings),
+             query,
+             nil,
+             settings,
+             request_fun,
+             false
+           ),
+         true <- is_list(payload) or {:error, :gitlab_unknown_payload} do
+      issues = normalize_state_page(payload, settings, requested_states)
+      updated_pages = [issues | pages]
+
+      if length(payload) < @page_size do
+        {:ok, updated_pages |> Enum.reverse() |> List.flatten()}
+      else
+        fetch_issue_pages(settings, state_query, requested_states, page + 1, request_fun, updated_pages)
+      end
+    end
+  end
+
+  defp fetch_issues_by_ids(ids, tracker_settings, request_fun) do
+    case Enum.uniq(ids) do
+      [] ->
+        {:ok, []}
+
+      unique_ids ->
+        with {:ok, gitlab_settings} <- settings(tracker_settings) do
+          fetch_issue_ids(unique_ids, gitlab_settings, request_fun, [])
+        end
+    end
+  end
+
+  defp fetch_issue_ids([], _settings, _request_fun, issues), do: {:ok, Enum.reverse(issues)}
+
+  defp fetch_issue_ids([id | rest], settings, request_fun, issues) do
+    with {:ok, iid} <- parse_iid(id),
+         {:ok, payload} <-
+           request_with_settings(
+             "GET",
+             project_issue_path(settings, iid),
+             %{},
+             nil,
+             settings,
+             request_fun,
+             true
+           ) do
+      continue_issue_id_fetch(payload, rest, settings, request_fun, issues)
+    end
+  end
+
+  defp continue_issue_id_fetch(:not_found, rest, settings, request_fun, issues) do
+    fetch_issue_ids(rest, settings, request_fun, issues)
+  end
+
+  defp continue_issue_id_fetch(%{} = raw_issue, rest, settings, request_fun, issues) do
+    case normalize_issue(raw_issue, settings) do
+      %Issue{} = issue -> fetch_issue_ids(rest, settings, request_fun, [issue | issues])
+      nil -> {:error, :gitlab_unknown_payload}
+    end
+  end
+
+  defp continue_issue_id_fetch(_payload, _rest, _settings, _request_fun, _issues) do
+    {:error, :gitlab_unknown_payload}
+  end
+
+  defp normalize_state_page(raw_issues, settings, requested_states) do
+    issues = Enum.map(raw_issues, &normalize_issue(&1, settings))
+    malformed_count = Enum.count(issues, &is_nil/1)
+
+    if malformed_count > 0 do
+      Logger.warning("Dropping malformed GitLab issue records count=#{malformed_count}")
+    end
+
+    issues
+    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(&MapSet.member?(requested_states, normalize_state(&1.state)))
+  end
+
+  defp normalize_issue(%{"iid" => iid, "title" => title, "state" => state} = issue, settings)
+       when is_integer(iid) and iid > 0 and is_binary(title) and is_binary(state) do
+    if present_string?(title) and present_string?(state) do
+      %Issue{
+        id: Integer.to_string(iid),
+        native_ref: native_ref(issue, settings.project_path),
+        identifier: "GL-#{iid}",
+        title: title,
+        description: blank_to_nil(issue["description"]),
+        priority: nil,
+        state: state,
+        branch_name: nil,
+        url: issue["web_url"],
+        assignee_id: assignee_id(issue),
+        labels: extract_labels(issue["labels"]),
+        blocked_by: [],
+        dispatchable: true,
+        created_at: parse_datetime(issue["created_at"]),
+        updated_at: parse_datetime(issue["updated_at"])
+      }
+    end
+  end
+
+  defp normalize_issue(_issue, _settings), do: nil
+
+  defp native_ref(issue, project_path) do
+    %{
+      "id" => issue["id"],
+      "iid" => issue["iid"],
+      "project_id" => issue["project_id"],
+      "project_path" => project_path,
+      "references" => issue["references"]
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp assignee_id(%{"assignees" => [assignee | _]}) when is_map(assignee), do: assignee_id(assignee)
+
+  defp assignee_id(%{"assignee" => assignee}) when is_map(assignee), do: assignee_id(assignee)
+
+  defp assignee_id(%{"id" => id}) when is_integer(id), do: Integer.to_string(id)
+
+  defp assignee_id(%{"username" => username}) when is_binary(username), do: username
+
+  defp assignee_id(_assignee), do: nil
+
+  defp extract_labels(labels) when is_list(labels) do
+    labels
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&(String.trim(&1) |> String.downcase()))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp extract_labels(_labels), do: []
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      text -> text
+    end
+  end
+
+  defp blank_to_nil(_value), do: nil
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> datetime
+      _ -> nil
+    end
+  end
+
+  defp parse_datetime(_value), do: nil
+
+  defp request_with_settings(method, path, query, body, settings, request_fun, allow_not_found) do
+    case request_fun.(method, path, query, body, settings) do
+      {:ok, %{status: status, body: payload}} when status in 200..299 ->
+        {:ok, payload}
+
+      {:ok, %{status: 404}} when allow_not_found ->
+        {:ok, :not_found}
+
+      {:ok, %{status: status}} when is_integer(status) ->
+        Logger.error("GitLab API request failed status=#{status} method=#{method} path=#{path}")
+        {:error, {:gitlab_api_status, status}}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _ ->
+        {:error, :gitlab_unknown_payload}
+    end
+  end
+
+  defp perform_request(method, path, query, body, settings) do
+    with {:ok, request_method} <- request_method(method) do
+      request_opts = [
+        method: request_method,
+        url: settings.api_url <> path,
+        headers: gitlab_headers(settings.api_key),
+        params: query,
+        connect_options: [timeout: 30_000]
+      ]
+
+      request_opts = if is_nil(body), do: request_opts, else: Keyword.put(request_opts, :json, body)
+
+      case Req.request(request_opts) do
+        {:ok, response} -> {:ok, %{status: response.status, body: response.body}}
+        {:error, reason} -> {:error, {:gitlab_api_request, reason}}
+      end
+    end
+  end
+
+  defp settings(tracker_settings) when is_map(tracker_settings) do
+    provider = provider_settings(tracker_settings)
+    api_url = provider["api_url"] || @default_api_url
+    project_path = resolve_setting(provider["project_path"], System.get_env("GITLAB_PROJECT_PATH"))
+
+    api_key = resolve_setting(provider["api_key"], System.get_env("GITLAB_PAT"))
+
+    cond do
+      not valid_api_url?(api_url) ->
+        {:error, :invalid_gitlab_api_url}
+
+      not present_string?(project_path) ->
+        {:error, :missing_gitlab_project_path}
+
+      not valid_project_path?(project_path) ->
+        {:error, :invalid_gitlab_project_path}
+
+      not present_string?(api_key) ->
+        {:error, :missing_gitlab_api_key}
+
+      true ->
+        {:ok,
+         %{
+           api_url: String.trim_trailing(api_url, "/"),
+           api_key: api_key,
+           project_path: project_path
+         }}
+    end
+  end
+
+  defp provider_settings(%{provider: provider}) when is_map(provider), do: provider
+  defp provider_settings(_tracker_settings), do: %{}
+
+  defp resolve_setting(nil, fallback), do: normalize_string(fallback)
+
+  defp resolve_setting("$" <> env_name, fallback) do
+    if valid_env_name?(env_name) do
+      normalize_string(System.get_env(env_name) || fallback)
+    else
+      nil
+    end
+  end
+
+  defp resolve_setting(value, _fallback), do: normalize_string(value)
+
+  defp normalize_string(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_string(_value), do: nil
+
+  defp env_reference_names(values) do
+    Enum.flat_map(values, fn
+      "$" <> env_name when is_binary(env_name) -> if valid_env_name?(env_name), do: [env_name], else: []
+      _ -> []
+    end)
+  end
+
+  defp valid_env_name?(name), do: String.match?(name, ~r/^[A-Za-z_][A-Za-z0-9_]*$/)
+
+  defp valid_api_url?(value) when is_binary(value) do
+    case URI.parse(value) do
+      %URI{scheme: "https", host: host} when is_binary(host) -> true
+      _ -> false
+    end
+  end
+
+  defp valid_api_url?(_value), do: false
+
+  defp valid_project_path?(value) when is_binary(value) do
+    not String.contains?(value, [" ", "\t", "\n", "\r", <<0>>])
+  end
+
+  defp valid_project_path?(_value), do: false
+
+  defp project_issues_path(settings), do: "/projects/#{encoded(settings.project_path)}/issues"
+
+  defp project_issue_path(settings, iid), do: "#{project_issues_path(settings)}/#{iid}"
+
+  defp gitlab_headers(api_key) do
+    [
+      {"Accept", "application/json"},
+      {"PRIVATE-TOKEN", api_key}
+    ]
+  end
+
+  defp gitlab_state_query(states) do
+    has_opened? = MapSet.member?(states, "opened")
+    has_closed? = MapSet.member?(states, "closed")
+
+    cond do
+      has_opened? and has_closed? -> "all"
+      has_opened? -> "opened"
+      has_closed? -> "closed"
+      true -> nil
+    end
+  end
+
+  defp parse_iid(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {iid, ""} when iid > 0 -> {:ok, iid}
+      _ -> {:error, :invalid_gitlab_issue_id}
+    end
+  end
+
+  defp parse_iid(_value), do: {:error, :invalid_gitlab_issue_id}
+
+  defp encoded(value), do: URI.encode(value, &URI.char_unreserved?/1)
+
+  defp request_method("GET"), do: {:ok, :get}
+  defp request_method("POST"), do: {:ok, :post}
+  defp request_method("PUT"), do: {:ok, :put}
+  defp request_method("DELETE"), do: {:ok, :delete}
+  defp request_method(_method), do: {:error, :invalid_gitlab_method}
+
+  defp normalize_state(value) when is_binary(value), do: value |> String.trim() |> String.downcase()
+  defp normalize_state(_value), do: ""
+
+  defp present_string?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_string?(_value), do: false
+end

--- a/elixir/lib/symphony_elixir/tracker.ex
+++ b/elixir/lib/symphony_elixir/tracker.ex
@@ -11,6 +11,7 @@ defmodule SymphonyElixir.Tracker do
   alias SymphonyElixir.Tracker.Issue
 
   @adapters %{
+    "gitlab" => SymphonyElixir.GitLab.Adapter,
     "linear" => SymphonyElixir.Linear.Adapter,
     "memory" => SymphonyElixir.Tracker.Memory
   }

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -14,6 +14,7 @@ defmodule SymphonyElixir.MixProject do
         ],
         ignore_modules: [
           SymphonyElixir.Config,
+          SymphonyElixir.GitLab.Client,
           SymphonyElixir.Linear.Client,
           SymphonyElixir.SpecsCheck,
           SymphonyElixir.Orchestrator,

--- a/elixir/test/symphony_elixir/gitlab_adapter_test.exs
+++ b/elixir/test/symphony_elixir/gitlab_adapter_test.exs
@@ -1,0 +1,487 @@
+defmodule SymphonyElixir.GitLab.AdapterTest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.GitLab.Adapter, as: GitLabAdapter
+  alias SymphonyElixir.GitLab.AgentTool, as: GitLabAgentTool
+  alias SymphonyElixir.GitLab.Client, as: GitLabClient
+
+  defmodule FakeGitLabClient do
+    def fetch_issues_by_states(states) do
+      send(self(), {:gitlab_states_called, states})
+      {:ok, states}
+    end
+
+    def fetch_issues_by_ids(ids) do
+      send(self(), {:gitlab_ids_called, ids})
+      {:ok, ids}
+    end
+  end
+
+  setup do
+    gitlab_client_module = Application.get_env(:symphony_elixir, :gitlab_client_module)
+
+    on_exit(fn ->
+      if is_nil(gitlab_client_module) do
+        Application.delete_env(:symphony_elixir, :gitlab_client_module)
+      else
+        Application.put_env(:symphony_elixir, :gitlab_client_module, gitlab_client_module)
+      end
+    end)
+
+    :ok
+  end
+
+  test "adapter validates GitLab config, delegates reads, and advertises gitlab_api" do
+    settings = tracker_settings()
+
+    assert :ok = GitLabAdapter.validate_config(settings)
+
+    assert {:error, :missing_gitlab_active_states} =
+             GitLabAdapter.validate_config(%{settings | active_states: nil})
+
+    assert {:error, :missing_gitlab_terminal_states} =
+             GitLabAdapter.validate_config(%{settings | terminal_states: nil})
+
+    assert :ok = GitLabAdapter.validate_config(%{settings | active_states: [], terminal_states: []})
+
+    assert {:error, :invalid_gitlab_states} =
+             GitLabAdapter.validate_config(%{settings | active_states: ["Todo"]})
+
+    assert {:error, :invalid_gitlab_states} =
+             GitLabAdapter.validate_config(%{settings | active_states: [42]})
+
+    assert {:error, :invalid_gitlab_states} =
+             GitLabAdapter.validate_config(%{settings | active_states: ["closed"]})
+
+    assert {:error, :invalid_gitlab_states} =
+             GitLabAdapter.validate_config(%{settings | terminal_states: ["opened"]})
+
+    Application.put_env(:symphony_elixir, :gitlab_client_module, FakeGitLabClient)
+
+    assert {:ok, ["opened"]} = GitLabAdapter.fetch_issues_by_states(["opened"])
+    assert_receive {:gitlab_states_called, ["opened"]}
+
+    assert {:ok, ["42"]} = GitLabAdapter.fetch_issues_by_ids(["42"])
+    assert_receive {:gitlab_ids_called, ["42"]}
+
+    assert [%{"name" => "gitlab_api"}] = GitLabAdapter.agent_tool_specs()
+
+    assert GitLabAdapter.execute_agent_tool(
+             "gitlab_api",
+             %{"method" => "GET", "path" => "/user"},
+             gitlab_client: fn _method, _path, _query, _body, _opts ->
+               {:ok, %{status: 200, body: %{"username" => "octocat"}}}
+             end
+           )["success"]
+  end
+
+  test "client validates project settings and declares token environments" do
+    assert :ok = GitLabClient.validate_settings(tracker_settings())
+
+    assert {:error, :missing_gitlab_project_path} =
+             GitLabClient.validate_settings(tracker_settings(%{"project_path" => 123}))
+
+    assert {:error, :invalid_gitlab_project_path} =
+             GitLabClient.validate_settings(tracker_settings(%{"project_path" => "group / project"}))
+
+    assert {:error, :missing_gitlab_api_key} =
+             GitLabClient.validate_settings(tracker_settings(%{"api_key" => 123}))
+
+    assert {:error, :invalid_gitlab_api_url} =
+             GitLabClient.validate_settings(tracker_settings(%{"api_url" => "not a url"}))
+
+    assert {:error, :invalid_gitlab_api_url} =
+             GitLabClient.validate_settings(tracker_settings(%{"api_url" => "http://gitlab.com/api/v4"}))
+
+    assert GitLabClient.secret_environment_names(tracker_settings(%{"api_key" => "$SYMPHONY_GITLAB_TOKEN"})) == ["GITLAB_PAT", "GITLAB_ACCESS_TOKEN", "SYMPHONY_GITLAB_TOKEN"]
+
+    assert {:ok, []} =
+             GitLabClient.fetch_issues_by_states_for_test(
+               ["opened"],
+               tracker_settings(%{"project_path" => " group/project ", "api_key" => " token "}),
+               fn "GET", "/projects/group%2Fproject/issues", _query, nil, settings ->
+                 assert settings.project_path == "group/project"
+                 assert settings.api_key == "token"
+                 {:ok, %{status: 200, body: []}}
+               end
+             )
+  end
+
+  test "client normalizes GitLab issues without dropping provider details" do
+    issue = GitLabClient.normalize_issue_for_test(raw_issue(42), tracker_settings())
+
+    assert issue.id == "42"
+    assert issue.identifier == "GL-42"
+
+    assert issue.native_ref == %{
+             "id" => 1_042,
+             "iid" => 42,
+             "project_id" => 77,
+             "project_path" => "group/project",
+             "references" => %{"full" => "group/project#42"}
+           }
+
+    assert issue.title == "Issue 42"
+    assert issue.description == "Body 42"
+    assert issue.state == "opened"
+    assert issue.url == "https://gitlab.test/group/project/-/issues/42"
+    assert issue.assignee_id == "99"
+    assert issue.labels == ["bug", "platform"]
+    assert issue.blocked_by == []
+    assert issue.dispatchable
+    assert %DateTime{} = issue.created_at
+    assert %DateTime{} = issue.updated_at
+
+    assert GitLabClient.normalize_issue_for_test(
+             raw_issue(43)
+             |> Map.put("state", "closed")
+             |> Map.put("confidential", true)
+             |> Map.put("issue_type", "incident"),
+             tracker_settings()
+           ).dispatchable
+
+    assert GitLabClient.normalize_issue_for_test(
+             raw_issue(45)
+             |> Map.delete("assignees")
+             |> Map.put("assignee", %{"username" => "fallback-user"}),
+             tracker_settings()
+           ).assignee_id == "fallback-user"
+
+    assert GitLabClient.normalize_issue_for_test(
+             Map.put(raw_issue(44), "title", " "),
+             tracker_settings()
+           ) == nil
+  end
+
+  test "client pages state reads, maps GitLab states, and drops malformed records" do
+    first_page =
+      Enum.map(1..98, &raw_issue/1) ++
+        [Map.put(raw_issue(99), "state", "closed"), Map.put(raw_issue(100), "title", "")]
+
+    request_fun = fn "GET", "/projects/group%2Fproject/issues", query, nil, settings ->
+      send(self(), {:gitlab_page, query, settings})
+
+      body =
+        case query["page"] do
+          1 -> first_page
+          2 -> [raw_issue(101)]
+        end
+
+      {:ok, %{status: 200, body: body}}
+    end
+
+    log =
+      capture_log(fn ->
+        assert {:ok, issues} =
+                 GitLabClient.fetch_issues_by_states_for_test(
+                   [" OPENED "],
+                   tracker_settings(),
+                   request_fun
+                 )
+
+        assert length(issues) == 99
+        assert hd(issues).id == "1"
+        assert List.last(issues).id == "101"
+        refute Enum.any?(issues, &(&1.id == "99"))
+      end)
+
+    assert log =~ "Dropping malformed GitLab issue records count=1"
+
+    assert_receive {:gitlab_page,
+                    %{
+                      "state" => "opened",
+                      "per_page" => 100,
+                      "page" => 1,
+                      "order_by" => "created_at",
+                      "sort" => "asc"
+                    }, %{project_path: "group/project"}}
+
+    assert_receive {:gitlab_page, %{"page" => 2}, %{project_path: "group/project"}}
+
+    all_request = fn "GET", "/projects/group%2Fproject/issues", query, nil, _settings ->
+      send(self(), {:gitlab_all_query, query})
+      {:ok, %{status: 200, body: []}}
+    end
+
+    assert {:ok, []} =
+             GitLabClient.fetch_issues_by_states_for_test(
+               ["opened", "closed"],
+               tracker_settings(),
+               all_request
+             )
+
+    assert_receive {:gitlab_all_query, %{"state" => "all"}}
+
+    assert {:ok, []} =
+             GitLabClient.fetch_issues_by_states_for_test(
+               ["Todo"],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 flunk("unsupported GitLab states should not make an HTTP request")
+               end
+             )
+
+    assert {:ok, []} =
+             GitLabClient.fetch_issues_by_states_for_test(
+               [],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 flunk("empty GitLab states should not make an HTTP request")
+               end
+             )
+  end
+
+  test "client refreshes IIDs in order, omits 404s, and rejects malformed refreshes" do
+    request_fun = fn "GET", path, %{}, nil, _settings ->
+      send(self(), {:gitlab_id_path, path})
+
+      case path do
+        "/projects/group%2Fproject/issues/2" -> {:ok, %{status: 200, body: raw_issue(2)}}
+        "/projects/group%2Fproject/issues/1" -> {:ok, %{status: 200, body: raw_issue(1)}}
+        "/projects/group%2Fproject/issues/404" -> {:ok, %{status: 404, body: %{"message" => "404 Not Found"}}}
+      end
+    end
+
+    assert {:ok, issues} =
+             GitLabClient.fetch_issues_by_ids_for_test(
+               ["2", "1", "404", "2"],
+               tracker_settings(),
+               request_fun
+             )
+
+    assert Enum.map(issues, & &1.id) == ["2", "1"]
+    assert_receive {:gitlab_id_path, "/projects/group%2Fproject/issues/2"}
+    assert_receive {:gitlab_id_path, "/projects/group%2Fproject/issues/1"}
+    assert_receive {:gitlab_id_path, "/projects/group%2Fproject/issues/404"}
+    refute_receive {:gitlab_id_path, "/projects/group%2Fproject/issues/2"}
+
+    assert {:error, :invalid_gitlab_issue_id} =
+             GitLabClient.fetch_issues_by_ids_for_test(
+               ["not-a-number"],
+               tracker_settings(),
+               request_fun
+             )
+
+    assert {:error, :gitlab_unknown_payload} =
+             GitLabClient.fetch_issues_by_ids_for_test(
+               ["3"],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 {:ok, %{status: 200, body: Map.put(raw_issue(3), "title", "")}}
+               end
+             )
+
+    assert {:ok, []} =
+             GitLabClient.fetch_issues_by_ids_for_test(
+               [],
+               tracker_settings(),
+               fn _method, _path, _query, _body, _settings ->
+                 flunk("empty GitLab IDs should not make an HTTP request")
+               end
+             )
+  end
+
+  test "gitlab_api preserves REST status and body while rejecting unsafe arguments" do
+    test_pid = self()
+    tracker_settings = tracker_settings()
+
+    response =
+      GitLabAgentTool.execute(
+        "gitlab_api",
+        %{
+          "method" => "post",
+          "path" => " /projects/group%2Fproject/issues/42/notes ",
+          "query" => %{"per_page" => 10},
+          "body" => %{"body" => "hello"}
+        },
+        tracker_settings: tracker_settings,
+        gitlab_client: fn method, path, query, body, opts ->
+          send(test_pid, {:gitlab_tool_called, method, path, query, body, opts})
+          {:ok, %{status: 201, body: %{"id" => 9}}}
+        end
+      )
+
+    assert_received {:gitlab_tool_called, "POST", "/projects/group%2Fproject/issues/42/notes", query, body, opts}
+
+    assert query == %{"per_page" => 10}
+    assert body == %{"body" => "hello"}
+    assert opts == [tracker_settings: tracker_settings]
+    assert response["success"] == true
+    assert Jason.decode!(response["output"]) == %{"status" => 201, "body" => %{"id" => 9}}
+    assert response["contentItems"] == [%{"type" => "inputText", "text" => response["output"]}]
+
+    failure =
+      GitLabAgentTool.execute(
+        "gitlab_api",
+        %{"method" => "GET", "path" => "/projects/1/issues/404"},
+        gitlab_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: 404, body: %{"message" => "404 Not Found"}}}
+        end
+      )
+
+    assert failure["success"] == false
+
+    assert Jason.decode!(failure["output"]) == %{
+             "status" => 404,
+             "body" => %{"message" => "404 Not Found"}
+           }
+
+    Enum.each(
+      [
+        %{"method" => "GET", "path" => "https://gitlab.com/api/v4/user"},
+        %{"method" => "PATCH", "path" => "/user"},
+        %{"method" => "GET", "path" => "/user", "query" => false},
+        %{"path" => "/user"}
+      ],
+      fn arguments ->
+        invalid =
+          GitLabAgentTool.execute(
+            "gitlab_api",
+            arguments,
+            gitlab_client: fn _method, _path, _query, _body, _opts ->
+              flunk("invalid gitlab_api arguments should not call the client")
+            end
+          )
+
+        assert invalid["success"] == false
+      end
+    )
+  end
+
+  test "gitlab_api reports unsupported tools, malformed calls, and client failures" do
+    unsupported = GitLabAgentTool.execute("not_gitlab_api", %{}, [])
+    assert unsupported["success"] == false
+    assert Jason.decode!(unsupported["output"])["error"]["supportedTools"] == ["gitlab_api"]
+
+    Enum.each(
+      ["not-an-object", %{"method" => "GET", "path" => 123}],
+      fn arguments ->
+        invalid =
+          GitLabAgentTool.execute(
+            "gitlab_api",
+            arguments,
+            gitlab_client: fn _method, _path, _query, _body, _opts ->
+              flunk("malformed gitlab_api arguments should not call the client")
+            end
+          )
+
+        assert invalid["success"] == false
+      end
+    )
+
+    malformed_response =
+      GitLabAgentTool.execute(
+        "gitlab_api",
+        %{"method" => "GET", "path" => "/user"},
+        gitlab_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: "not-an-integer", body: %{}}}
+        end
+      )
+
+    assert malformed_response["success"] == false
+
+    Enum.each(
+      [:missing_gitlab_api_key, {:gitlab_api_request, :timeout}, :unexpected_failure],
+      fn reason ->
+        failure =
+          GitLabAgentTool.execute(
+            "gitlab_api",
+            %{"method" => "GET", "path" => "/user"},
+            gitlab_client: fn _method, _path, _query, _body, _opts ->
+              {:error, reason}
+            end
+          )
+
+        assert failure["success"] == false
+        assert %{"error" => %{"message" => message}} = Jason.decode!(failure["output"])
+        assert is_binary(message)
+      end
+    )
+
+    non_json_body =
+      GitLabAgentTool.execute(
+        "gitlab_api",
+        %{"method" => "GET", "path" => "/user"},
+        gitlab_client: fn _method, _path, _query, _body, _opts ->
+          {:ok, %{status: 200, body: self()}}
+        end
+      )
+
+    assert non_json_body["success"]
+    assert non_json_body["output"] =~ "#PID"
+  end
+
+  test "tracker binds GitLab tools and token env names from provider config" do
+    token_env = "SYMPHONY_GITLAB_TOKEN_#{System.unique_integer([:positive])}"
+    previous_token = System.get_env(token_env)
+    System.put_env(token_env, "test-token")
+
+    on_exit(fn -> restore_env(token_env, previous_token) end)
+
+    write_gitlab_workflow!(Workflow.workflow_file_path(), "$#{token_env}")
+
+    binding = Tracker.bind_agent_tools()
+
+    assert binding.adapter == GitLabAdapter
+    assert binding.secret_environment_names == ["GITLAB_PAT", "GITLAB_ACCESS_TOKEN", token_env]
+    assert [%{"name" => "gitlab_api"}] = binding.tool_specs
+    assert :ok = Config.validate!()
+  end
+
+  defp tracker_settings(provider_overrides \\ %{}) do
+    %{
+      kind: "gitlab",
+      provider:
+        Map.merge(
+          %{
+            "project_path" => "group/project",
+            "api_key" => "test-token"
+          },
+          provider_overrides
+        ),
+      active_states: ["opened"],
+      terminal_states: ["closed"]
+    }
+  end
+
+  defp raw_issue(iid) do
+    %{
+      "iid" => iid,
+      "id" => 1_000 + iid,
+      "project_id" => 77,
+      "title" => "Issue #{iid}",
+      "description" => " Body #{iid} ",
+      "state" => "opened",
+      "web_url" => "https://gitlab.test/group/project/-/issues/#{iid}",
+      "assignees" => [%{"id" => 99, "username" => "octocat"}],
+      "assignee" => %{"username" => "octocat"},
+      "labels" => [" Bug ", "bug", "Platform"],
+      "references" => %{"full" => "group/project##{iid}"},
+      "created_at" => "2026-01-01T00:00:00Z",
+      "updated_at" => "2026-01-02T00:00:00Z"
+    }
+  end
+
+  defp write_gitlab_workflow!(path, token) do
+    File.write!(
+      path,
+      """
+      ---
+      tracker:
+        kind: gitlab
+        provider:
+          project_path: "group/project"
+          api_key: #{Jason.encode!(token)}
+        active_states: ["opened"]
+        terminal_states: ["closed"]
+      ---
+
+      You are working on {{ issue.identifier }}.
+      """
+    )
+
+    if Process.whereis(SymphonyElixir.WorkflowStore) do
+      assert :ok = SymphonyElixir.WorkflowStore.force_reload()
+    end
+  end
+end

--- a/elixir/test/symphony_elixir/gitlab_live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/gitlab_live_e2e_test.exs
@@ -1,0 +1,425 @@
+defmodule SymphonyElixir.GitLab.LiveE2ETest do
+  use SymphonyElixir.TestSupport
+
+  alias SymphonyElixir.GitLab.Client, as: GitLabClient
+
+  @moduletag :live_e2e
+  @moduletag timeout: 300_000
+
+  @api_url "https://gitlab.com/api/v4"
+  @result_file "LIVE_GITLAB_E2E_RESULT.txt"
+  @live_e2e_skip_reason if(System.get_env("SYMPHONY_RUN_GITLAB_LIVE_E2E") != "1",
+                          do: "set SYMPHONY_RUN_GITLAB_LIVE_E2E=1 to enable the real GitLab/Codex end-to-end test"
+                        )
+
+  @tag skip: @live_e2e_skip_reason
+  test "creates a real GitLab issue and closes it through gitlab_api" do
+    project_id = required_env!("SYMPHONY_LIVE_GITLAB_PROJECT_ID")
+    token = required_env!("GITLAB_PAT")
+    run_id = "symphony-gitlab-live-e2e-#{System.unique_integer([:positive])}"
+    test_root = Path.join(System.tmp_dir!(), run_id)
+    workflow_root = Path.join(test_root, "workflow")
+    workflow_file = Path.join(workflow_root, "WORKFLOW.md")
+    workspace_root = Path.join(test_root, "workspaces")
+    codex_home = isolated_codex_home!(test_root)
+    original_workflow_path = Workflow.workflow_file_path()
+    runtime_pid = Process.whereis(SymphonyElixir.AgentRuntimeSupervisor)
+
+    File.mkdir_p!(workflow_root)
+
+    issue_payload =
+      create_issue!(
+        project_id,
+        token,
+        "Symphony GitLab live e2e #{run_id}",
+        "Disposable issue created by the Symphony GitLab live E2E test."
+      )
+
+    issue_iid = Integer.to_string(issue_payload["iid"])
+    expected_comment = expected_comment("GL-#{issue_iid}", run_id)
+
+    try do
+      assert %Issue{} =
+               issue =
+               GitLabClient.normalize_issue_for_test(
+                 issue_payload,
+                 tracker_settings(project_id)
+               )
+
+      stop_agent_runtime_if_running(runtime_pid)
+      Workflow.set_workflow_file_path(workflow_file)
+
+      write_workflow!(
+        workflow_file,
+        project_id,
+        workspace_root,
+        codex_home,
+        live_prompt(project_id, expected_comment)
+      )
+
+      assert %Issue{id: state_issue_id} = wait_for_open_state_issue!(issue.id)
+      assert state_issue_id == issue.id
+
+      assert {:ok, [%Issue{id: issue_id, identifier: identifier}]} =
+               Tracker.fetch_issues_by_ids([issue.id])
+
+      assert issue_id == issue.id
+      assert identifier == issue.identifier
+
+      assert :ok = AgentRunner.run(issue, self(), max_turns: 3)
+
+      runtime_info = receive_runtime_info!(issue.id)
+      tool_calls = completed_gitlab_tool_calls(issue.id)
+
+      assert File.read!(Path.join(runtime_info.workspace_path, @result_file)) ==
+               expected_result(issue.identifier, project_id)
+
+      assert %{"state" => "closed"} = get_issue!(project_id, token, issue.id)
+
+      assert notes!(project_id, token, issue.id)
+             |> Enum.any?(&(&1["body"] == expected_comment))
+
+      issue_path = "/projects/#{project_id}/issues/#{issue.id}"
+      notes_path = issue_path <> "/notes"
+
+      assert_tool_call_count!(tool_calls, "GET", issue_path, 2)
+      assert_tool_call_count!(tool_calls, "GET", notes_path, 2)
+      assert_tool_call!(tool_calls, "POST", notes_path, %{"body" => expected_comment})
+      assert_tool_call!(tool_calls, "PUT", issue_path, %{"state_event" => "close"})
+    after
+      close_result = close_issue(project_id, token, issue_iid)
+      delete_result = delete_issue(project_id, token, issue_iid)
+      Workflow.set_workflow_file_path(original_workflow_path)
+      restart_agent_runtime_if_needed(runtime_pid)
+      File.rm_rf(test_root)
+      assert :ok = close_result
+      assert :ok = delete_result
+      assert :not_found = get_issue(project_id, token, issue_iid)
+    end
+  end
+
+  defp tracker_settings(project_id) do
+    %{
+      kind: "gitlab",
+      provider: %{"project_path" => project_id, "api_key" => "test-token"},
+      active_states: ["opened"],
+      terminal_states: ["closed"]
+    }
+  end
+
+  defp write_workflow!(path, project_id, workspace_root, codex_home, prompt) do
+    File.write!(
+      path,
+      """
+      ---
+      tracker:
+        kind: gitlab
+        provider:
+          project_path: #{Jason.encode!(project_id)}
+          api_key: "$GITLAB_PAT"
+        active_states: ["opened"]
+        terminal_states: ["closed"]
+      workspace:
+        root: #{Jason.encode!(workspace_root)}
+      agent:
+        max_turns: 3
+      codex:
+        command: #{Jason.encode!("env CODEX_HOME=#{shell_escape(codex_home)} codex app-server")}
+        approval_policy: "never"
+        read_timeout_ms: 60000
+        turn_timeout_ms: 600000
+        stall_timeout_ms: 600000
+      observability:
+        dashboard_enabled: false
+      ---
+
+      #{prompt}
+      """
+    )
+
+    assert :ok = SymphonyElixir.WorkflowStore.force_reload()
+  end
+
+  defp live_prompt(project_id, expected_comment) do
+    issue_path = "/projects/#{project_id}/issues/{{ issue.id }}"
+    notes_path = issue_path <> "/notes"
+
+    """
+    You are running a real Symphony GitLab end-to-end test.
+
+    The current working directory is the workspace root.
+
+    Step 1:
+    Run exactly:
+
+    ```sh
+    if [ -n "${GITLAB_PAT:-}" ]; then gitlab_pat_present=yes; else gitlab_pat_present=no; fi
+    if [ -n "${GITLAB_ACCESS_TOKEN:-}" ]; then gitlab_access_token_present=yes; else gitlab_access_token_present=no; fi
+    cat > #{@result_file} <<EOF
+    identifier={{ issue.identifier }}
+    project_id=#{project_id}
+    gitlab_pat_present=$gitlab_pat_present
+    gitlab_access_token_present=$gitlab_access_token_present
+    EOF
+    ```
+
+    Then verify the file with `cat #{@result_file}`. Both secret-presence lines must end in `no`.
+
+    Step 2:
+    You must use `gitlab_api` for every GitLab operation. First GET both:
+    - #{issue_path}
+    - #{notes_path}
+
+    If the exact comment below is not already present, POST it once to #{notes_path} with a JSON body containing a single `body` field:
+    #{expected_comment}
+
+    Step 3:
+    PUT #{issue_path} with `{"state_event": "close"}`.
+
+    Step 4:
+    Use `gitlab_api` again to GET #{issue_path} and #{notes_path}. Stop only after:
+    1. #{@result_file} has the exact four lines above and both secret-presence values are `no`
+    2. the exact comment is present
+    3. the GitLab issue state is `closed`
+
+    Do not ask for approval.
+    """
+  end
+
+  defp expected_result(identifier, project_id) do
+    "identifier=#{identifier}\nproject_id=#{project_id}\ngitlab_pat_present=no\ngitlab_access_token_present=no\n"
+  end
+
+  defp expected_comment(identifier, run_id) do
+    "Symphony GitLab live e2e comment\nidentifier=#{identifier}\nrun_id=#{run_id}"
+  end
+
+  defp create_issue!(project_id, token, title, description) do
+    response =
+      gitlab_request!(
+        :post,
+        "/projects/#{project_id}/issues",
+        token,
+        %{"title" => title, "description" => description}
+      )
+
+    case response.body do
+      %{"iid" => iid} = issue when is_integer(iid) -> issue
+      _ -> flunk("GitLab issue create returned an unexpected payload")
+    end
+  end
+
+  defp get_issue!(project_id, token, issue_iid) do
+    case get_issue(project_id, token, issue_iid) do
+      %{} = issue -> issue
+      :not_found -> flunk("GitLab issue read unexpectedly returned 404")
+    end
+  end
+
+  defp get_issue(project_id, token, issue_iid) do
+    case gitlab_request(:get, "/projects/#{project_id}/issues/#{issue_iid}", token, nil) do
+      {:ok, %{status: status, body: %{} = issue}} when status in 200..299 -> issue
+      {:ok, %{status: 404}} -> :not_found
+      {:ok, %{status: status}} -> flunk("GitLab issue read failed with HTTP #{status}")
+      {:error, reason} -> flunk("GitLab issue read failed before a response: #{inspect(reason)}")
+    end
+  end
+
+  defp notes!(project_id, token, issue_iid) do
+    response =
+      gitlab_request!(
+        :get,
+        "/projects/#{project_id}/issues/#{issue_iid}/notes",
+        token,
+        nil,
+        %{"per_page" => 100}
+      )
+
+    case response.body do
+      notes when is_list(notes) -> notes
+      _ -> flunk("GitLab issue notes read returned an unexpected payload")
+    end
+  end
+
+  defp close_issue(project_id, token, issue_iid) do
+    case gitlab_request(
+           :put,
+           "/projects/#{project_id}/issues/#{issue_iid}",
+           token,
+           %{"state_event" => "close"}
+         ) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: 404}} -> :ok
+      {:ok, %{status: status}} -> {:error, {:gitlab_cleanup_status, status}}
+      {:error, reason} -> {:error, {:gitlab_cleanup_request, reason}}
+    end
+  end
+
+  defp delete_issue(project_id, token, issue_iid) do
+    case gitlab_request(:delete, "/projects/#{project_id}/issues/#{issue_iid}", token, nil) do
+      {:ok, %{status: status}} when status in 200..299 -> :ok
+      {:ok, %{status: 404}} -> :ok
+      {:ok, %{status: status}} -> {:error, {:gitlab_delete_status, status}}
+      {:error, reason} -> {:error, {:gitlab_delete_request, reason}}
+    end
+  end
+
+  defp gitlab_request!(method, path, token, body, query \\ %{}) do
+    case gitlab_request(method, path, token, body, query) do
+      {:ok, %{status: status} = response} when status in 200..299 -> response
+      {:ok, %{status: status}} -> flunk("GitLab request failed with HTTP #{status}")
+      {:error, reason} -> flunk("GitLab request failed before a response: #{inspect(reason)}")
+    end
+  end
+
+  defp gitlab_request(method, path, token, body, query \\ %{}) do
+    request_opts = [
+      method: method,
+      url: @api_url <> path,
+      headers: [
+        {"Accept", "application/json"},
+        {"PRIVATE-TOKEN", token}
+      ],
+      params: query,
+      connect_options: [timeout: 30_000]
+    ]
+
+    request_opts = if is_nil(body), do: request_opts, else: Keyword.put(request_opts, :json, body)
+
+    case Req.request(request_opts) do
+      {:ok, response} -> {:ok, %{status: response.status, body: response.body}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp receive_runtime_info!(issue_id) do
+    receive do
+      {:worker_runtime_info, ^issue_id, %{workspace_path: workspace_path} = runtime_info}
+      when is_binary(workspace_path) ->
+        runtime_info
+
+      {:codex_worker_update, ^issue_id, _message} ->
+        receive_runtime_info!(issue_id)
+    after
+      5_000 ->
+        flunk("timed out waiting for worker runtime info")
+    end
+  end
+
+  defp completed_gitlab_tool_calls(issue_id, calls \\ []) do
+    receive do
+      {:codex_worker_update, ^issue_id, %{event: :tool_call_completed, payload: %{"params" => params}}} ->
+        completed_gitlab_tool_calls(issue_id, [params | calls])
+
+      {:codex_worker_update, ^issue_id, _message} ->
+        completed_gitlab_tool_calls(issue_id, calls)
+    after
+      0 ->
+        Enum.reverse(calls)
+    end
+  end
+
+  defp assert_tool_call!(calls, method, path, expected_body) do
+    found? =
+      Enum.any?(calls, fn params ->
+        tool_call_matches?(params, method, path) and
+          (expected_body == :any or get_in(params, ["arguments", "body"]) == expected_body)
+      end)
+
+    assert found?, "expected completed gitlab_api #{method} #{path}"
+  end
+
+  defp assert_tool_call_count!(calls, method, path, expected_count) do
+    count = Enum.count(calls, &tool_call_matches?(&1, method, path))
+    assert count >= expected_count, "expected at least #{expected_count} completed gitlab_api #{method} #{path} calls"
+  end
+
+  defp tool_call_matches?(params, method, path) do
+    arguments = Map.get(params, "arguments", %{})
+    tool_name = Map.get(params, "name") || Map.get(params, "tool")
+    called_method = Map.get(arguments, "method")
+    called_path = Map.get(arguments, "path")
+
+    tool_name == "gitlab_api" and is_binary(called_method) and
+      String.upcase(String.trim(called_method)) == method and
+      is_binary(called_path) and String.trim(called_path) == path
+  end
+
+  defp wait_for_open_state_issue!(issue_id, attempts \\ 20)
+
+  defp wait_for_open_state_issue!(issue_id, attempts) when attempts > 0 do
+    case Tracker.fetch_issues_by_states(["opened"]) do
+      {:ok, issues} ->
+        case Enum.find(issues, &(&1.id == issue_id)) do
+          %Issue{} = issue ->
+            issue
+
+          nil ->
+            Process.sleep(500)
+            wait_for_open_state_issue!(issue_id, attempts - 1)
+        end
+
+      {:error, reason} ->
+        flunk("GitLab state read failed: #{inspect(reason)}")
+    end
+  end
+
+  defp wait_for_open_state_issue!(_issue_id, 0) do
+    flunk("new GitLab issue did not appear in the open-state adapter read")
+  end
+
+  defp isolated_codex_home!(test_root) do
+    codex_home = Path.join(test_root, "codex-home")
+    auth_json_path = Path.join(codex_home, "auth.json")
+
+    source_auth_json =
+      Path.join(
+        System.get_env("CODEX_HOME") || Path.join(System.user_home!(), ".codex"),
+        "auth.json"
+      )
+
+    unless File.regular?(source_auth_json) do
+      flunk("live GitLab e2e requires Codex auth")
+    end
+
+    File.mkdir_p!(codex_home)
+    File.cp!(source_auth_json, auth_json_path)
+    File.chmod!(auth_json_path, 0o600)
+    codex_home
+  end
+
+  defp stop_agent_runtime_if_running(runtime_pid) when is_pid(runtime_pid) do
+    assert :ok =
+             Supervisor.terminate_child(
+               SymphonyElixir.Supervisor,
+               SymphonyElixir.AgentRuntimeSupervisor
+             )
+  end
+
+  defp stop_agent_runtime_if_running(_runtime_pid), do: :ok
+
+  defp restart_agent_runtime_if_needed(runtime_pid) when is_pid(runtime_pid) do
+    if is_nil(Process.whereis(SymphonyElixir.AgentRuntimeSupervisor)) do
+      case Supervisor.restart_child(
+             SymphonyElixir.Supervisor,
+             SymphonyElixir.AgentRuntimeSupervisor
+           ) do
+        {:ok, _pid} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+  end
+
+  defp restart_agent_runtime_if_needed(_runtime_pid), do: :ok
+
+  defp required_env!(name) do
+    case System.get_env(name) do
+      value when is_binary(value) and value != "" -> value
+      _ -> flunk("live GitLab e2e requires #{name}")
+    end
+  end
+
+  defp shell_escape(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+end


### PR DESCRIPTION
#### Context

Symphony's generic tracker seam needs a GitLab Issues implementation without adding generic mutation APIs.

#### TL;DR

*Add GitLab Issues reads and a host-authenticated raw GitLab API tool.*

#### Summary

- Add project-scoped GitLab issue reads, IID normalization, and dispatchability.
- Add raw `gitlab_api` for provider-native mutations with host-side auth.
- Add contract tests, live E2E proof, and GitLab adapter documentation.

#### Alternatives

- Generic CRUD was rejected because it would flatten GitLab-specific issue capabilities.
- Header pagination machinery was rejected because simple page/per-page reads are sufficient.

#### Test Plan

- [x] `make -C elixir all`
- [x] `SYMPHONY_RUN_GITLAB_LIVE_E2E=1 mix test test/symphony_elixir/gitlab_live_e2e_test.exs`
- [x] `SYMPHONY_RUN_LIVE_E2E=1 SYMPHONY_LIVE_LINEAR_TEAM_KEY=FST mix test test/symphony_elixir/live_e2e_test.exs:123`
