### PR TITLE
Retry failed workspace setup and anchor local roots

### DIFF
--- a/elixir/lib/symphony_elixir/codex/app_server.ex
+++ b/elixir/lib/symphony_elixir/codex/app_server.ex
@@ -151,7 +151,7 @@ defmodule SymphonyElixir.Codex.AppServer do
 
   defp validate_workspace_cwd(workspace, nil) when is_binary(workspace) do
     expanded_workspace = Path.expand(workspace)
-    expanded_root = Path.expand(Config.settings!().workspace.root)
+    expanded_root = Config.local_workspace_root()
     expanded_root_prefix = expanded_root <> "/"
 
     with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -85,6 +85,13 @@ defmodule SymphonyElixir.Config do
     end
   end
 
+  @doc false
+  @spec local_workspace_root() :: Path.t()
+  def local_workspace_root do
+    workflow_dir = Workflow.workflow_file_path() |> Path.expand() |> Path.dirname()
+    Path.expand(settings!().workspace.root, workflow_dir)
+  end
+
   @spec validate!() :: :ok | {:error, term()}
   def validate! do
     WorkflowStore.force_reload()

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -20,9 +20,15 @@ defmodule SymphonyElixir.Workspace do
 
       with {:ok, workspace} <- workspace_path_for_issue(safe_id, worker_host),
            :ok <- validate_workspace_path(workspace, worker_host),
-           {:ok, workspace, created?} <- ensure_workspace(workspace, worker_host),
-           :ok <- maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do
-        {:ok, workspace}
+           {:ok, workspace, created?} <- ensure_workspace(workspace, worker_host) do
+        case maybe_run_after_create_hook(workspace, issue_context, created?, worker_host) do
+          :ok ->
+            {:ok, workspace}
+
+          {:error, _reason} = error ->
+            cleanup_failed_new_workspace(workspace, created?, worker_host)
+            error
+        end
       end
     rescue
       error in [ArgumentError, ErlangError, File.Error] ->
@@ -213,7 +219,7 @@ defmodule SymphonyElixir.Workspace do
   end
 
   defp workspace_path_for_issue(safe_id, nil) when is_binary(safe_id) do
-    Config.settings!().workspace.root
+    Config.local_workspace_root()
     |> Path.join(safe_id)
     |> PathSafety.canonicalize()
   end
@@ -267,6 +273,30 @@ defmodule SymphonyElixir.Workspace do
 
       false ->
         :ok
+    end
+  end
+
+  defp cleanup_failed_new_workspace(_workspace, false, _worker_host), do: :ok
+
+  defp cleanup_failed_new_workspace(workspace, true, nil) do
+    case File.rm_rf(workspace) do
+      {:ok, _removed} ->
+        :ok
+
+      {:error, reason, path} ->
+        Logger.warning("Failed to remove partial workspace path=#{path} reason=#{inspect(reason)}")
+    end
+  end
+
+  defp cleanup_failed_new_workspace(workspace, true, worker_host) when is_binary(worker_host) do
+    script = [remote_shell_assign("workspace", workspace), "rm -rf \"$workspace\""] |> Enum.join("\n")
+
+    case run_remote_command(worker_host, script, Config.settings!().hooks.timeout_ms) do
+      {:ok, {_output, 0}} ->
+        :ok
+
+      result ->
+        Logger.warning("Failed to remove partial workspace worker_host=#{worker_host_for_log(worker_host)} result=#{inspect(result)}")
     end
   end
 
@@ -402,7 +432,7 @@ defmodule SymphonyElixir.Workspace do
 
   defp validate_workspace_path(workspace, nil) when is_binary(workspace) do
     expanded_workspace = Path.expand(workspace)
-    expanded_root = Path.expand(Config.settings!().workspace.root)
+    expanded_root = Config.local_workspace_root()
     expanded_root_prefix = expanded_root <> "/"
 
     with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -57,6 +57,29 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert String.starts_with?(Path.basename(first_workspace), "MT_Det--")
   end
 
+  test "relative local workspace roots resolve from the workflow directory" do
+    workflow_dir = Path.dirname(Workflow.workflow_file_path())
+    launcher_dir = Path.join(System.tmp_dir!(), "symphony-elixir-launcher-#{System.unique_integer([:positive])}")
+    original_cwd = File.cwd!()
+
+    try do
+      File.mkdir_p!(launcher_dir)
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: "relative-workspaces")
+      File.cd!(launcher_dir)
+
+      assert {:ok, expected_workspace} =
+               SymphonyElixir.PathSafety.canonicalize(Path.join([workflow_dir, "relative-workspaces", "MT-REL"]))
+
+      assert {:ok, workspace} = Workspace.create_for_issue("MT-REL")
+
+      assert workspace == expected_workspace
+      refute String.starts_with?(workspace, launcher_dir <> "/")
+    after
+      File.cd!(original_cwd)
+      File.rm_rf(launcher_dir)
+    end
+  end
+
   test "workspace keys disambiguate identifiers that sanitize to the same path" do
     workspace_root =
       Path.join(
@@ -238,6 +261,38 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
                Workspace.create_for_issue("MT-FAIL")
     after
       File.rm_rf(workspace_root)
+    end
+  end
+
+  test "workspace retries after_create after a failed new workspace bootstrap" do
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "symphony-elixir-workspace-hook-retry-#{System.unique_integer([:positive])}"
+      )
+
+    workspace_root = Path.join(test_root, "workspaces")
+    attempt_log = Path.join(test_root, "after-create-attempts")
+
+    try do
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        hook_after_create: """
+        if [ -f "#{attempt_log}" ]; then count=$(wc -l < "#{attempt_log}"); else count=0; fi
+        printf 'attempt\\n' >> "#{attempt_log}"
+        if [ "$count" -eq 0 ]; then printf partial > partial.txt; exit 17; fi
+        printf ready > READY
+        """
+      )
+
+      assert {:error, {:workspace_hook_failed, "after_create", 17, _output}} =
+               Workspace.create_for_issue("MT-FAIL-RETRY")
+
+      assert {:ok, workspace} = Workspace.create_for_issue("MT-FAIL-RETRY")
+      assert File.read!(Path.join(workspace, "READY")) == "ready"
+      assert String.split(String.trim(File.read!(attempt_log)), "\n") == ["attempt", "attempt"]
+    after
+      File.rm_rf(test_root)
     end
   end
 


### PR DESCRIPTION
#### Context

Failed new-workspace bootstrap was skipped on retry, and relative local roots followed launcher cwd instead of the selected workflow file.

#### TL;DR

*Retry failed bootstrap cleanly and anchor local roots to WORKFLOW.md.*

#### Summary

- Remove newly created partial workspaces when `after_create` fails.
- Resolve local relative roots from the selected workflow directory.
- Keep remote roots raw and use the local root in app-server validation.
- Add regressions for bootstrap retry and explicit workflow paths.

#### Alternatives

- Marker files and global cwd changes were unnecessary; one local root helper keeps the fix small.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs:60`
- [x] `mise exec -- mix test test/symphony_elixir/workspace_and_config_test.exs:244`
