### PR TITLE
Gate Jira new-category issues on blockers

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -261,6 +261,8 @@ codex:
   and accept `$VAR`. Set explicit Jira-native `active_states` and `terminal_states`.
 - Issues and reads: candidate reads and ID refreshes stay scoped to the configured project and
   requested statuses; `issue.id` is Jira's immutable ID and `issue.identifier` is the issue key.
+- Blockers: inward `Blocks` links populate `blocked_by`; issues in Jira's `new` status category
+  wait until blockers reach configured terminal states, while in-progress categories keep running.
 - Tool: `jira_rest` sends relative `/rest/api/3/` requests host-side with configured Basic auth,
   strips token environment variables from Codex, and can reach whatever the Jira credential can.
 

--- a/elixir/lib/symphony_elixir/jira/client.ex
+++ b/elixir/lib/symphony_elixir/jira/client.ex
@@ -232,6 +232,7 @@ defmodule SymphonyElixir.Jira.Client do
        when is_binary(id) and is_binary(key) and is_map(fields) do
     title = fields["summary"]
     state = get_in(fields, ["status", "name"])
+    status_category = get_in(fields, ["status", "statusCategory", "key"])
     blockers = extract_blockers(fields["issuelinks"])
 
     if same_project_key?(issue_project_key(%{"fields" => fields}), settings.project_key) and
@@ -250,7 +251,7 @@ defmodule SymphonyElixir.Jira.Client do
         assignee_id: get_in(fields, ["assignee", "accountId"]),
         labels: extract_labels(fields["labels"]),
         blocked_by: blockers,
-        dispatchable: dispatchable?(state, blockers, settings.terminal_states),
+        dispatchable: dispatchable?(state, status_category, blockers, settings.terminal_states),
         created_at: parse_datetime(fields["created"]),
         updated_at: parse_datetime(fields["updated"])
       }
@@ -333,9 +334,18 @@ defmodule SymphonyElixir.Jira.Client do
     }
   end
 
-  defp dispatchable?(state, blockers, terminal_states) do
-    normalize_state(state) not in ["todo", "to do"] or
+  defp dispatchable?(state, status_category, blockers, terminal_states) do
+    not blocks_gate_dispatch?(state, status_category) or
       Enum.all?(blockers, &terminal_blocker?(&1, terminal_states))
+  end
+
+  defp blocks_gate_dispatch?(_state, status_category)
+       when is_binary(status_category) and status_category != "" do
+    normalize_state(status_category) == "new"
+  end
+
+  defp blocks_gate_dispatch?(state, _status_category) do
+    normalize_state(state) in ["todo", "to do"]
   end
 
   defp terminal_blocker?(%{state: state}, terminal_states)

--- a/elixir/test/symphony_elixir/jira_adapter_test.exs
+++ b/elixir/test/symphony_elixir/jira_adapter_test.exs
@@ -197,6 +197,16 @@ defmodule SymphonyElixir.Jira.AdapterTest do
 
     refute normalized.dispatchable
 
+    open =
+      issue
+      |> put_in(
+        ["fields", "status"],
+        %{"name" => "Open", "statusCategory" => %{"key" => "new"}}
+      )
+      |> JiraClient.normalize_issue_for_test(tracker_settings())
+
+    refute open.dispatchable
+
     terminal_only =
       issue
       |> put_in(["fields", "issuelinks"], [
@@ -225,7 +235,10 @@ defmodule SymphonyElixir.Jira.AdapterTest do
 
     in_progress =
       issue
-      |> put_in(["fields", "status", "name"], "In Progress")
+      |> put_in(
+        ["fields", "status"],
+        %{"name" => "In Progress", "statusCategory" => %{"key" => "indeterminate"}}
+      )
       |> JiraClient.normalize_issue_for_test(tracker_settings())
 
     assert in_progress.dispatchable


### PR DESCRIPTION
#### Context

Jira blockers only gated literal Todo states, so Open or Backlog issues could dispatch through active blockers.

#### TL;DR

*Gate Jira new-category issues on active blockers.*

#### Summary

- Read Jira `statusCategory.key` while normalizing issues.
- Gate `new` category issues on inward `Blocks` links.
- Preserve the Todo fallback and keep in-progress work dispatchable.
- Document the adapter rule and add an Open-state regression.

#### Alternatives

- Shared scheduler policy was unnecessary; Jira already exposes the native category signal.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mise exec -- mix test test/symphony_elixir/jira_adapter_test.exs:166`
