### PR TITLE
docs(elixir): document default polling interval

### DIFF
--- a/elixir/README.md
+++ b/elixir/README.md
@@ -210,7 +210,9 @@ codex:
   supported. `required_labels`, `active_states`, and `terminal_states` stay under `tracker`.
 - Scope and paging: candidate reads filter the configured project slug and requested state names,
   following Linear pages of 50. ID refreshes are also project-scoped and batch up to 50 IDs. Empty
-  state/ID lists return `{:ok, []}` without a Linear request.
+  state/ID lists return `{:ok, []}` without a Linear request. In the checked-in default workflow,
+  Symphony polls the configured Linear project every 5 seconds by default; configure this with
+  `polling.interval_ms` in `WORKFLOW.md`.
 - Identity and normalization: `issue.id` is the Linear issue ID and `issue.native_ref` is currently
   `nil`. Records missing a nonblank ID, identifier, title, or state are dropped from candidate
   pages and fail ID refreshes. State keeps Linear's spelling; integer priorities are preserved and


### PR DESCRIPTION
#### Context

The default workflow polls Linear every 5 seconds, but the Elixir README did not surface that cadence near the Linear polling docs.

#### TL;DR

*Document the default Linear polling interval and where to configure it.*

#### Summary

- Add a concise note to the Linear adapter profile in `elixir/README.md`.
- State the checked-in workflow polls the configured Linear project every 5 seconds by default.
- Point readers to `polling.interval_ms` in `WORKFLOW.md` for configuration.

#### Alternatives

- Update `WORKFLOW.md`; rejected because the configured default is already present there.
- Add a new section; rejected because the Linear adapter profile is the most relevant location.

#### Test Plan

- [x] `make -C elixir all`
- [x] `make -C elixir fmt-check`
- [x] `awk`/`rg` check that `WORKFLOW.md` uses `interval_ms: 5000` and README mentions the 5-second default plus `polling.interval_ms`.
